### PR TITLE
Make downloadpdb return the filename again

### DIFF
--- a/src/pdb.jl
+++ b/src/pdb.jl
@@ -163,7 +163,7 @@ end
 """
     downloadpdb(pdbid::AbstractString; <keyword arguments>)
 
-Download PDB or biological assembly file from the RCSB server.
+Download PDB or biological assembly file from the RCSB server and returns the path to the file.
 
 # Arguments
 - `pdbid::AbstractString`: the PDB to be downloaded.

--- a/src/pdb.jl
+++ b/src/pdb.jl
@@ -248,6 +248,8 @@ function downloadpdb(pdbid::AbstractString; pdb_dir::AbstractString=pwd(), file_
             rm(archivefilepath, force=true)
         end
     end
+
+    return pdbpath
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,8 @@ pdbfilepath(filename::AbstractString) = joinpath(fmtdir, "PDB", filename)
     @test_throws ArgumentError downloadpdb("1alw", pdb_dir=pdb_dir, file_format=PDBXML, ba_number=1)
     # Invalid ba_number for PDB "1alw"
     @test_throws ErrorException downloadpdb("1alw",pdb_dir=pdb_dir, file_format=MMCIF,ba_number=10)
+    # Tests if downloadpdb returns the correct path to the downloaded file
+    @test isfile(downloadpdb("1crn"))
 
     # PDB format
     downloadpdb("1alw", pdb_dir=pdb_dir, file_format=PDB)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ pdbfilepath(filename::AbstractString) = joinpath(fmtdir, "PDB", filename)
     # Invalid ba_number for PDB "1alw"
     @test_throws ErrorException downloadpdb("1alw",pdb_dir=pdb_dir, file_format=MMCIF,ba_number=10)
     # Tests if downloadpdb returns the correct path to the downloaded file
-    @test isfile(downloadpdb("1crn"))
+    @test isfile(downloadpdb("1crn", pdb_dir=pdb_dir))
 
     # PDB format
     downloadpdb("1alw", pdb_dir=pdb_dir, file_format=PDB)


### PR DESCRIPTION
A while ago downloadpdb returned the path to the downloaded file, which allowed for this:

`prot = read(downloadpdb("1crn"), PDB)`

PR #483 broke this behavior, so here is a simple fix :) 

I also added a test for it.