### PR TITLE
Julia syntax updates

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -99,7 +99,7 @@ An atom that is part of a macromolecule - either an `Atom` or a
 abstract type AbstractAtom <: StructuralElement end
 
 "An atom that is part of a macromolecule."
-immutable Atom <: AbstractAtom
+struct Atom <: AbstractAtom
     serial::Int
     name::String
     alt_loc_id::Char
@@ -112,7 +112,7 @@ immutable Atom <: AbstractAtom
 end
 
 "A container to hold different locations of the same atom."
-immutable DisorderedAtom <: AbstractAtom
+struct DisorderedAtom <: AbstractAtom
     alt_loc_ids::Dict{Char, Atom}
     default::Char
 end
@@ -125,7 +125,7 @@ A residue (amino acid) or other molecule - either a`Residue` or a
 abstract type AbstractResidue <: StructuralElement end
 
 "A residue (amino acid) or other molecule."
-immutable Residue <: AbstractResidue
+struct Residue <: AbstractResidue
     name::String
     number::Int
     ins_code::Char
@@ -136,14 +136,14 @@ immutable Residue <: AbstractResidue
 end
 
 "A container to hold different versions of the same residue (point mutations)."
-immutable DisorderedResidue <: AbstractResidue
+struct DisorderedResidue <: AbstractResidue
     names::Dict{String, Residue}
     default::String
 end
 
 
 "A chain (molecule) from a macromolecular structure."
-immutable Chain <: StructuralElement
+struct Chain <: StructuralElement
     id::Char
     res_list::Vector{String}
     residues::Dict{String, AbstractResidue}
@@ -152,7 +152,7 @@ end
 
 
 "A conformation of a macromolecular structure."
-immutable Model <: StructuralElement
+struct Model <: StructuralElement
     number::Int
     chains::Dict{Char, Chain}
     structure::StructuralElement
@@ -160,7 +160,7 @@ end
 
 
 "A container for multiple `Model`s."
-immutable ProteinStructure <: StructuralElement
+struct ProteinStructure <: StructuralElement
     name::String
     models::Dict{Int, Model}
 end
@@ -170,7 +170,7 @@ end
 A record for a single atom, e.g. as represented in a Protein Data Bank (PDB)
 file.
 """
-immutable AtomRecord
+struct AtomRecord
     het_atom::Bool
     serial::Int
     atom_name::String

--- a/src/model.jl
+++ b/src/model.jl
@@ -928,14 +928,14 @@ Base.eltype(::Type{DisorderedAtom}) = Atom
 Returns a copy of a `Vector` of `StructuralElement`s with all elements that do
 not return `true` from the selector functions removed.
 """
-function applyselectors{T <: StructuralElement}(els::Vector{T}, selectors::Function...)
+function applyselectors(els::Vector{T}, selectors::Function...) where {T <: StructuralElement}
     new_list = copy(els)
     applyselectors!(new_list, selectors...)
     return new_list
 end
 
 "Runs `applyselectors` in place."
-function applyselectors!{T <: StructuralElement}(els::Vector{T}, selectors::Function...)
+function applyselectors!(els::Vector{T}, selectors::Function...) where {T <: StructuralElement}
     for selector in selectors
         filter!(selector, els)
     end
@@ -956,7 +956,7 @@ collectmodels(el::Union{Chain, AbstractResidue, AbstractAtom}) = [model(el)]
 
 collectmodels(mods::Vector{Model}) = sort(mods)
 
-function collectmodels{T <: Union{Chain, AbstractResidue, AbstractAtom}}(els::Vector{T})
+function collectmodels(els::Vector{T}) where {T <: Union{Chain, AbstractResidue, AbstractAtom}}
     mod_list = Model[]
     for el in els
         if !(model(el) in mod_list)
@@ -1017,7 +1017,7 @@ end
 
 collectchains(chs::Vector{Chain}) = sort(chs)
 
-function collectchains{T <: Union{AbstractResidue, AbstractAtom}}(els::Vector{T})
+function collectchains(els::Vector{T}) where {T <: Union{AbstractResidue, AbstractAtom}}
     ch_list = Chain[]
     for el in els
         if !(chain(el) in ch_list)
@@ -1077,9 +1077,9 @@ collectresidues(at::AbstractAtom) = AbstractResidue[residue(at)]
 
 # Note output is always Vector{AbstractResidue} unless input was Vector{Residue}
 # or Vector{DisorderedResidue}, in which case output is same type as input type
-collectresidues{T <: AbstractResidue}(res_list::Vector{T}) = sort(res_list)
+collectresidues(res_list::Vector{T}) where {T <: AbstractResidue} = sort(res_list)
 
-function collectresidues{T <: AbstractAtom}(at_list::Vector{T})
+function collectresidues(at_list::Vector{T}) where {T <: AbstractAtom}
     res_list = AbstractResidue[]
     for at in at_list
         if !(residue(at) in res_list)
@@ -1141,7 +1141,7 @@ collectatoms(at::AbstractAtom) = AbstractAtom[at]
 
 # Note output is always Vector{AbstractAtom} unless input was Vector{Atom} or
 # Vector{DisorderedAtom}, in which case output is same type as input type
-collectatoms{T <: AbstractAtom}(at_list::Vector{T}) = sort(at_list)
+collectatoms(at_list::Vector{T}) where {T <: AbstractAtom} = sort(at_list)
 
 function collectatoms(el::StructuralElementOrList, atom_selector::Function, atom_selectors::Function...)
     return applyselectors(collectatoms(el), atom_selector, atom_selectors...)
@@ -1465,7 +1465,7 @@ function AminoAcidSequence(ch::Chain, residue_selectors::Function...)
         sort(collectresidues(ch, residue_selectors...), by=resnumber))
 end
 
-function AminoAcidSequence{T <: AbstractResidue}(res::Vector{T})
+function AminoAcidSequence(res::Vector{T}) where {T <: AbstractResidue}
     seq = BioSymbols.AminoAcid[]
     for i in 1:length(res)
         if haskey(BioSymbols.threeletter_to_aa, resname(res[i]))

--- a/src/pdb.jl
+++ b/src/pdb.jl
@@ -21,16 +21,16 @@ export
 
 
 "Protein Data Bank (PDB) file formats."
-immutable PDB <: BioCore.IO.FileFormat end
-immutable PDBXML <: BioCore.IO.FileFormat end
-immutable MMCIF <: BioCore.IO.FileFormat end
-immutable MMTF <: BioCore.IO.FileFormat end
+struct PDB <: BioCore.IO.FileFormat end
+struct PDBXML <: BioCore.IO.FileFormat end
+struct MMCIF <: BioCore.IO.FileFormat end
+struct MMTF <: BioCore.IO.FileFormat end
 
 # A Dict mapping the type to their file extensions
 const pdbextension = Dict{Type,String}( PDB => ".pdb", PDBXML => ".xml", MMCIF => ".cif", MMTF => ".mmtf")
 
 "Error arising from parsing a Protein Data Bank (PDB) file."
-type PDBParseError <: Exception
+struct PDBParseError <: Exception
     message::String
     line_number::Int
     line::String

--- a/src/pdb.jl
+++ b/src/pdb.jl
@@ -778,9 +778,9 @@ function writepdb(output::IO, at::AbstractAtom, atom_selectors::Function...)
     end
 end
 
-function writepdb{T <: AbstractAtom}(output::IO,
-                    ats::Vector{T},
-                    atom_selectors::Function...)
+function writepdb(output::IO,
+                ats::Vector{T},
+                atom_selectors::Function...) where {T <: AbstractAtom}
     for at in collectatoms(ats, atom_selectors...)
         writepdb(output, at)
     end


### PR DESCRIPTION
Updates to syntax:
- `immutable` to `struct`
- `where {T}` function syntax

Also `PDBParseError` becomes a `struct` which it should have been anyway.