### PR TITLE
mmCIF reader and writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 BioStructures provides functionality to read, write and manipulate
 macromolecular structures, in particular proteins.
-[Protein Data Bank](https://www.rcsb.org/pdb/home/home.do) (PDB) format files
-can be read in to a hierarchical data structure. Basic spatial calculations and
-functions to access the PDB are also provided.
+[Protein Data Bank](https://www.rcsb.org/pdb/home/home.do) (PDB) and mmCIF
+format files can be read in to a hierarchical data structure. Basic spatial
+calculations and functions to access the PDB are also provided.
 
 ## Installation
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.6
 Libz 0.2
+Formatting
 BioCore
 BioSymbols
 BioSequences

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 Libz 0.2
 Formatting
-BioCore
+BioCore 1.3.0
 BioSymbols
 BioSequences

--- a/docs/src/documentation.md
+++ b/docs/src/documentation.md
@@ -1,6 +1,6 @@
 # BioStructures documentation
 
-The BioStructures.jl package provides functionality to manipulate macromolecular structures, and in particular to read and write [Protein Data Bank](http://www.rcsb.org/pdb/home/home.do) (PDB) files. It is designed to be used for standard structural analysis tasks, as well as acting as a platform on which others can build to create more specific tools. It compares favourably in terms of performance to other PDB parsers - see some [benchmarks](https://github.com/jgreener64/pdb-benchmarks).
+The BioStructures.jl package provides functionality to manipulate macromolecular structures, and in particular to read and write [Protein Data Bank](http://www.rcsb.org/pdb/home/home.do) (PDB) and mmCIF files. It is designed to be used for standard structural analysis tasks, as well as acting as a platform on which others can build to create more specific tools. It compares favourably in terms of performance to other PDB parsers - see some [benchmarks](https://github.com/jgreener64/pdb-benchmarks).
 
 
 ## Basics
@@ -29,7 +29,17 @@ Number of hydrogens         -  0
 Number of disordered atoms  -  27
 ```
 
-**Note** : Refer to [Downloading PDB files](#downloading-pdb-files) and [Reading PDB files](#reading-pdb-files) sections for more options.
+mmCIF files can be read into the same data structure with `read("/path/to/cif/file.cif", MMCIF)`. If you want to read an mmCIF file into a dictionary to query yourself (e.g. to access metadata fields), use `MMCIFDict`:
+
+```julia
+julia> mmcif_dict = MMCIFDict("/path/to/cif/file.cif")
+mmCIF dictionary with 716 fields
+
+julia> mmcif_dict["_entity_src_nat.common_name"]
+"great nettle"
+```
+
+Refer to [Downloading PDB files](#downloading-pdb-files) and [Reading PDB files](#reading-pdb-files) sections for more options.
 
 The elements of `struc` can be accessed as follows:
 
@@ -224,13 +234,13 @@ julia> rad2deg(psiangle(struc['A'], 50))
 
 ## Downloading PDB files
 
-To download a PDB file to a specify directory:
+To download a PDB file to a specified directory:
 
 ```julia
 downloadpdb("1EN2", pdb_dir="path/to/pdb/directory/")
 ```
 
-To download multiple PDB files to a specify directory:
+To download multiple PDB files to a specified directory:
 
 ```julia
 downloadpdb(["1EN2","1ALW","1AKE"], pdb_dir="path/to/pdb/directory/")
@@ -249,20 +259,20 @@ downloadpdb("1ALW", pdb_dir="path/to/pdb/directory/", file_format=MMCIF)
 downloadpdb("1ALW", pdb_dir="path/to/pdb/directory/", file_format=MMTF)
 ```
 
-Various options can be set through optional keyword arguments when downloading PDB files as follows:
+Various options can be set through optional keyword arguments when downloading PDB files:
 
-| Keyword Argument               | Description                                                                                                           |
-| :----------------------------- | :-------------------------------------------------------------------------------------------------------------------- |
-| `pdb_dir::AbstractString=pwd()`| The directory to which the PDB file is downloaded                                                                     |
-| `file_format::Type=PDB`        | The format of the PDB file. Options are PDB, PDBXML, MMCIF or MMTF                                                    |
-| `obsolete::Bool=false`         | If set `true`, the PDB file is downloaded into the auto-generated "obsolete" directory inside the specified `pdb_dir` |
-| `overwrite::Bool=false`        | If set `true`, overwrites the PDB file if exists in `pdb_dir`; by default skips downloading the PDB file              |
-| `ba_number::Integer=0`         | If set > 0, downloads the respective biological assembly; by default downloads the PDB file                           |
+| Keyword Argument                | Description                                                                                                           |
+| :------------------------------ | :-------------------------------------------------------------------------------------------------------------------- |
+| `pdb_dir::AbstractString=pwd()` | The directory to which the PDB file is downloaded                                                                     |
+| `file_format::Type=PDB`         | The format of the PDB file. Options are PDB, PDBXML, MMCIF or MMTF                                                    |
+| `obsolete::Bool=false`          | If set `true`, the PDB file is downloaded into the auto-generated "obsolete" directory inside the specified `pdb_dir` |
+| `overwrite::Bool=false`         | If set `true`, overwrites the PDB file if exists in `pdb_dir`; by default skips downloading the PDB file              |
+| `ba_number::Integer=0`          | If set > 0, downloads the respective biological assembly; by default downloads the PDB file                           |
 
 
 ## Reading PDB files
 
-To parse a existing PDB file into a Structure-Model-Chain-Residue-Atom framework:
+To parse an existing PDB file into a Structure-Model-Chain-Residue-Atom framework:
 
 ```julia
 julia> struc = read("/path/to/pdb/file.pdb", PDB)
@@ -279,16 +289,16 @@ Number of hydrogens         -  0
 Number of disordered atoms  -  27
 ```
 
-Various options can be set through optional keyword arguments when parsing a PDB file as follows:
+Read a mmCIF file instead by replacing `PDB` with `MMCIF`. Various options can be set through optional keyword arguments when parsing PDB/mmCIF files:
 
-| Keyword Argument                             | Description                                                                     |
-| :------------------------------------------- | :------------------------------------------------------------------------------ |
-| `structure_name::AbstractString`             | The name of the PDB Structure read. Defaults to the given filename              |
-| `remove_disorder::Bool=false`                | If set true, then disordered atoms wont be parsed                               |
-| `read_std_atoms::Bool=true`                  | If set false, then standard ATOM records wont be parsed                         |
-| `read_het_atoms::Bool=true`                  | If set false, then HETATOM records wont be parsed                               |
+| Keyword Argument                             | Description                                                                        |
+| :------------------------------------------- | :--------------------------------------------------------------------------------- |
+| `structure_name::AbstractString`             | The name to give the resulting `ProteinStructure` - defaults to the given filename |
+| `remove_disorder::Bool=false`                | If set to `true`, only one location for disordered atoms will be parsed            |
+| `read_std_atoms::Bool=true`                  | If set to `false`, standard ATOM records wont be parsed                            |
+| `read_het_atoms::Bool=true`                  | If set to `false`, HETATOM records wont be parsed                                  |
 
-The function `readpdb` provides an uniform way to download and read PDB files. To parse a PDB file by specifying the PDB ID and PDB directory into a Structure-Model-Chain-Residue-Atom framework (file name must be in upper case, e.g. "1EN2.pdb"):
+The function `readpdb` provides a different way to download and read PDB files in line with `downloadpdb`. To parse a PDB file by specifying the PDB ID and PDB directory (file name must be in upper case, e.g. "1EN2.pdb"):
 
 ```julia
 struc = readpdb("1EN2", pdb_dir="/path/to/pdb/directory")
@@ -315,18 +325,18 @@ Number of hydrogens         -  0
 Number of disordered atoms  -  0
 ```
 
-Various options can be set through optional keyword arguments when downloading and parsing a PDB file as follows:
+Various options can be set when using `retrievepdb`:
 
-| Keyword Argument                             | Description                                                                                                      |
-| :--------------------------------------------| :--------------------------------------------------------------------------------------------------------------- |
-| `pdb_dir::AbstractString=pwd()`              | The directory from which the PDB file is read                                                                    |
-| `obsolete::Bool=false`                       | If set `true`, PDB file is downloaded into the auto-generated "obsolete" directory inside the specified `pdb_dir`|
-| `overwrite::Bool=false`                      | if set `true`, overwrites the PDB file if exists in `pdb_dir`; by default skips downloading PDB file if exists   |
-| `ba_number::Integer=0`                       | If set > 0 reads the respective biological assembly; by default reads PDB file                                   |
-| `structure_name::AbstractString="$pdbid.pdb"`| The name of the PDB Structure read. Defaults to "< PDBID >.pdb"                                                  |
-| `remove_disorder::Bool=false`                | If set true, then disordered atoms wont be parsed                                                                |
-| `read_std_atoms::Bool=true`                  | If set false, then standard ATOM records wont be parsed                                                          |
-| `read_het_atoms::Bool=true`                  | If set false, then HETATOM records wont be parsed                                                                |
+| Keyword Argument                              | Description                                                                                                          |
+| :-------------------------------------------- | :------------------------------------------------------------------------------------------------------------------- |
+| `pdb_dir::AbstractString=pwd()`               | The directory to which the PDB file is downloaded                                                                    |
+| `obsolete::Bool=false`                        | If set to `true`, PDB file is downloaded into the auto-generated "obsolete" directory inside the specified `pdb_dir` |
+| `overwrite::Bool=false`                       | if set to `true`, overwrites the PDB file if exists in `pdb_dir`; by default skips downloading PDB file if exists    |
+| `ba_number::Integer=0`                        | If set to > 0 reads the respective biological assembly; by default reads PDB file                                    |
+| `structure_name::AbstractString="$pdbid.pdb"` | The name to give the resulting `ProteinStructure` - defaults to "$pdbid.pdb"                                         |
+| `remove_disorder::Bool=false`                 | If set to `true`, only one location for disordered atoms will be parsed                                              |
+| `read_std_atoms::Bool=true`                   | If set to `false`, standard ATOM records wont be parsed                                                              |
+| `read_het_atoms::Bool=true`                   | If set to `false`, HETATOM records wont be parsed                                                                    |
 
 
 ## Writing PDB files
@@ -343,13 +353,19 @@ Any element type can be given as input to `writepdb`. Atom selectors can also be
 writepdb("1EN2_out.pdb", struc, backboneselector)
 ```
 
+To write mmCIF format files, use the `writemmcif` function with similar arguments. A `MMCIFDict` can also be written using `writemmcif`:
+
+```julia
+writemmcif("1EN2_out.dic", mmcif_dict)
+```
+
 
 ## RCSB PDB Utility Functions
 
 To download the entire RCSB PDB database in your preferred file format:
 
 ```julia
-downloadentirepdb(pdb_dir="path/to/pdb/directory/", file_format=MMTF, overwrite=false)
+downloadentirepdb(pdb_dir="path/to/pdb/directory/", file_format=MMTF)
 ```
 
 The keyword arguments are described below:
@@ -378,11 +394,9 @@ The `file_format` specfies the format in which the PDB files are downloaded; Opt
 
 If `overwrite=true`, the existing PDB files in obsolete directory will be overwritten by the newly downloaded ones.
 
-To maintain a local copy of the entire RCSB PDB Database
+To maintain a local copy of the entire RCSB PDB Database: run the `downloadentirepdb` function once to download all PDB files and set up a CRON job or similar to run `updatelocalpdb` function once a week to keep the local PDB directory up to date with the RCSB Server.
 
-Run the `downloadentirepdb` function once to download all PDB files and setup a CRON job or similar to run `updatelocalpdb` function once in every week to keep the local PDB directory up to date with the RCSB Server.
-
-There are a few more functions that may help.
+There are a few more functions that may help:
 
 | Function           | Returns                                                                         | Return type                                              |
 | :----------------- | :------------------------------------------------------------------------------ | :------------------------------------------------------- |
@@ -396,16 +410,16 @@ There are a few more functions that may help.
 
 A few further examples of BioStructures usage are given below.
 
-**A)** To plot the temperature factors of a protein, if you have Gadfly installed:
+**A)** To plot the temperature factors of a protein, if you have Plots installed:
 
 ```julia
-using Gadfly
+using Plots
 calphas = collectatoms(struc, calphaselector)
-plot(x=resnumber.(calphas),
-     y=tempfactor.(calphas),
-     Guide.xlabel("Residue number"),
-     Guide.ylabel("Temperature factor"),
-     Geom.line)
+plot(resnumber.(calphas),
+     tempfactor.(calphas),
+     xlabel="Residue number",
+     ylabel="Temperature factor",
+     label="")
 ```
 
 **B)** To print the PDB records for all C-alpha atoms within 5 Angstroms of residue 38:
@@ -437,17 +451,21 @@ end
 
 `contactmap` can also be given two structural elements as arguments, in which case a non-symmetrical 2D array is returned showing contacts between the elements.
 
-**E)** To show the Ramachandran phi/psi angle plot of a structure, if you have Gadfly installed:
+**E)** To show the Ramachandran phi/psi angle plot of a structure, if you have Plots installed:
 
 ```julia
-using Gadfly
+using Plots
 phi_angles, psi_angles = ramachandranangles(struc, standardselector)
-plot(x=rad2deg.(phi_angles),
-     y=rad2deg.(psi_angles),
-     Guide.xlabel("Phi / degrees"),
-     Guide.ylabel("Psi / degrees"),
-     Guide.xticks(ticks=[-180,-90,0,90,180]),
-     Guide.yticks(ticks=[-180,-90,0,90,180]))
+scatter(rad2deg.(phi_angles),
+     rad2deg.(psi_angles),
+     title="Ramachandran plot",
+     xlabel="Phi / degrees",
+     ylabel="Psi / degrees",
+     label="",
+     xticks=[-180,-90,0,90,180],
+     yticks=[-180,-90,0,90,180],
+     xlims=(-180,180),
+     ylims=(-180,180))
 ```
 
 **F)** To calculate the RMSD and displacements between the heavy (non-hydrogen) atoms of two models in an NMR structure:

--- a/docs/src/documentation.md
+++ b/docs/src/documentation.md
@@ -46,13 +46,14 @@ The elements of `struc` can be accessed as follows:
 | Command                     | Returns                                                                         | Return type       |
 | :-------------------------- | :------------------------------------------------------------------------------ | :---------------- |
 | `struc[1]`                  | Model 1                                                                         | `Model`           |
-| `struc[1]['A']`             | Model 1, chain A                                                                | `Chain`           |
-| `struc['A']`                | The lowest model (model 1), chain A                                             | `Chain`           |
-| `struc['A']["50"]`          | Model 1, chain A, residue 50                                                    | `AbstractResidue` |
-| `struc['A'][50]`            | Shortcut to above if it is not a hetero residue and the insertion code is blank | `AbstractResidue` |
-| `struc['A']["H_90"]`        | Model 1, chain A, hetero residue 90                                             | `AbstractResidue` |
-| `struc['A'][50]["CA"]`      | Model 1, chain A, residue 50, atom name CA                                      | `AbstractAtom`    |
-| `struc['A'][15]["CG"]['A']` | For disordered atoms, access a specific location                                | `Atom`            |
+| `struc[1]["A"]`             | Model 1, chain A                                                                | `Chain`           |
+| `struc[1]['A']`             | Shortcut to above if the chain ID is a single character                         | `Chain`           |
+| `struc["A"]`                | The lowest model (model 1), chain A                                             | `Chain`           |
+| `struc["A"]["50"]`          | Model 1, chain A, residue 50                                                    | `AbstractResidue` |
+| `struc["A"][50]`            | Shortcut to above if it is not a hetero residue and the insertion code is blank | `AbstractResidue` |
+| `struc["A"]["H_90"]`        | Model 1, chain A, hetero residue 90                                             | `AbstractResidue` |
+| `struc["A"][50]["CA"]`      | Model 1, chain A, residue 50, atom name CA                                      | `AbstractAtom`    |
+| `struc["A"][15]["CG"]['A']` | For disordered atoms, access a specific location                                | `Atom`            |
 
 Disordered atoms are stored in a `DisorderedAtom` container but calls fall back to the default atom, so disorder can be ignored if you are not interested in it.
 
@@ -88,13 +89,13 @@ Properties can be retrieved as follows:
 | `isdisorderedres`  | `true` if the residue has multiple residue names              | `Bool`                          |
 | `disorderedres`    | Access a particular residue name in a `DisorderedResidue`     | `Residue`                       |
 | `chain`            | Chain a residue or atom belongs to                            | `Chain`                         |
-| `chainid`          | Chain ID of a chain, residue or atom                          | `Char`                          |
+| `chainid`          | Chain ID of a chain, residue or atom                          | `String`                        |
 | `resids`           | Sorted residue IDs in a chain                                 | `Array{String,1}`               |
 | `residues`         | Dictionary of residues in a chain                             | `Dict{String, AbstractResidue}` |
 | `model`            | Model a chain, residue or atom belongs to                     | `Model`                         |
 | `modelnumber`      | Model number of a model, chain, residue or atom               | `Int`                           |
-| `chainids`         | Sorted chain IDs in a model or structure                      | `Array{Char,1}`                 |
-| `chains`           | Dictionary of chains in a model or structure                  | `Dict{Char, Chain}`             |
+| `chainids`         | Sorted chain IDs in a model or structure                      | `Array{String,1}`               |
+| `chains`           | Dictionary of chains in a model or structure                  | `Dict{String, Chain}`           |
 | `structure`        | Structure a model, chain, residue or atom belongs to          | `ProteinStructure`              |
 | `structurename`    | Name of the structure an element belongs to                   | `String`                        |
 | `modelnumbers`     | Sorted model numbers in a structure                           | `Array{Int,1}`                  |
@@ -121,7 +122,7 @@ for mod in struc
 end
 ```
 
-Models are ordered numerically; chains are ordered by character, except the empty chain is last; residues are ordered by residue number and insertion code with hetero residues after standard residues; atoms are ordered by atom serial.
+Models are ordered numerically; chains are ordered by chain ID character ordering, except the empty chain is last; residues are ordered by residue number and insertion code with hetero residues after standard residues; atoms are ordered by atom serial.
 
 `collect` can be used to get arrays of sub-elements. `collectatoms`, `collectresidues`, `collectchains` and `collectmodels` return arrays of a particular type from a structural element or element array.
 
@@ -315,7 +316,7 @@ INFO: Parsing the PDB file...
 BioStructures.ProteinStructure
 Name                        -  1ALW.pdb
 Number of models            -  1
-Chain(s)                    -  AB
+Chain(s)                    -  A,B
 Number of residues          -  346
 Number of point mutations   -  0
 Number of other molecules   -  10
@@ -358,6 +359,8 @@ To write mmCIF format files, use the `writemmcif` function with similar argument
 ```julia
 writemmcif("1EN2_out.dic", mmcif_dict)
 ```
+
+Multi-character chain IDs can be written to mmCIF files but will throw an error when written to a PDB file.
 
 
 ## RCSB PDB Utility Functions

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,9 +19,9 @@
 
 BioStructures provides functionality to read, write and manipulate
 macromolecular structures, in particular proteins.
-[Protein Data Bank](https://www.rcsb.org/pdb/home/home.do) (PDB) format files
-can be read in to a hierarchical data structure. Basic spatial calculations and
-functions to access the PDB are also provided.
+[Protein Data Bank](https://www.rcsb.org/pdb/home/home.do) (PDB) and mmCIF
+format files can be read in to a hierarchical data structure. Basic spatial
+calculations and functions to access the PDB are also provided.
 
 ## Installation
 

--- a/src/BioStructures.jl
+++ b/src/BioStructures.jl
@@ -18,6 +18,7 @@ import BioSequences.AminoAcidSequence
 
 include("model.jl")
 include("pdb.jl")
+include("mmcif.jl")
 include("spatial.jl")
 
 end # BioStructures

--- a/src/BioStructures.jl
+++ b/src/BioStructures.jl
@@ -11,6 +11,7 @@ __precompile__()
 module BioStructures
 
 using Libz
+using Formatting
 import BioCore
 import BioCore.distance
 import BioSymbols

--- a/src/mmcif.jl
+++ b/src/mmcif.jl
@@ -172,7 +172,16 @@ function MMCIFDict(f::IO)
                     continue
                 end
             else
-                push!(mmcif_dict[keys[i % n + 1]], token)
+                try
+                    push!(mmcif_dict[keys[i % n + 1]], token)
+                catch ex
+                    # A zero division error means we have not found any keys
+                    if isa(ex, DivideError)
+                        throw(ArgumentError("Loop keys not found, token: \"$token\""))
+                    else
+                        rethrow()
+                    end
+                end
                 i += 1
                 continue
             end

--- a/src/mmcif.jl
+++ b/src/mmcif.jl
@@ -148,8 +148,8 @@ function MMCIFDict(f::IO)
     key = ""
     keys = String[]
     loop_flag = false
-    i = 0
-    n = 0
+    i = 0 # Value counter
+    n = 0 # Key counter
     for token in tokens[2:end]
         if lowercase(token) == "loop_"
             loop_flag = true
@@ -235,7 +235,7 @@ AtomRecord(d::MMCIFDict, i::Integer) = AtomRecord(
     d["_atom_site.auth_atom_id"][i],
     d["_atom_site.label_alt_id"][i] in missingvals ? ' ' : d["_atom_site.label_alt_id"][i][1],
     d["_atom_site.auth_comp_id"][i],
-    d["_atom_site.auth_asym_id"][i][1],
+    d["_atom_site.auth_asym_id"][i],
     parse(Int, d["_atom_site.auth_seq_id"][i]),
     d["_atom_site.pdbx_PDB_ins_code"][i] in missingvals ? ' ' : d["_atom_site.pdbx_PDB_ins_code"][i][1],
     [
@@ -426,7 +426,7 @@ function writemmcif(output::IO,
     # Collect residues then expand out disordered residues
     for res in collectresidues(loop_el)
         model_n = string(modelnumber(res))
-        chain_id = chainid(res) == ' ' ? "." : string(chainid(res))
+        chain_id = strip(chainid(res)) == "" ? "." : chainid(res)
         res_n = string(resnumber(res))
         het = ishetero(res) ? "HETATM" : "ATOM"
         if isa(res, Residue)
@@ -459,7 +459,7 @@ function writemmcif(output::IO, at::AbstractAtom, atom_selectors::Function...)
     atom_dict["data_"] = structurename(at)
     for atom_record in at
         appendatom!(atom_dict, atom_record, string(modelnumber(at)),
-            chainid(at) == ' ' ? "." : string(chainid(at)),
+            strip(chainid(at)) == "" ? "." : chainid(at),
             string(resnumber(at)), resname(at),
             ishetero(at) ? "HETATM" : "ATOM")
     end
@@ -475,7 +475,7 @@ function writemmcif(output::IO,
     for at in collectatoms(ats, atom_selectors...)
         for atom_record in at
             appendatom!(atom_dict, atom_record, string(modelnumber(at)),
-                chainid(at) == ' ' ? "." : string(chainid(at)),
+                strip(chainid(at)) == "" ? "." : chainid(at),
                 string(resnumber(at)), resname(at),
                 ishetero(at) ? "HETATM" : "ATOM")
         end

--- a/src/mmcif.jl
+++ b/src/mmcif.jl
@@ -177,6 +177,9 @@ function MMCIFDict(f::IO)
     mmcif_dict = MMCIFDict()
     tokens = tokenizecif(f)
     # Data label token is read first
+    if length(tokens) == 0
+        return mmcif_dict
+    end
     data_token = first(tokens)
     mmcif_dict[data_token[1:5]] = data_token[6:end]
     return populatedict!(mmcif_dict, tokens[2:end])

--- a/src/mmcif.jl
+++ b/src/mmcif.jl
@@ -9,7 +9,10 @@ const missingvals = Set([".", "?"])
 const specialchars = Set(['_', '#', '\$', '[', ']', ';'])
 const specialwords = Set(["loop_", "stop_", "global_"])
 
-"A mmCIF dictionary."
+"""
+A mmCIF dictionary.
+Keys are field names and values are `String` or `Vector{String}`.
+"""
 struct MMCIFDict
     dict::Dict{String, Union{String, Vector{String}}}
 end
@@ -460,11 +463,11 @@ function appendatom!(atom_dict, at, model_n, chain_id, res_n, res_name, het) # a
 
     #push!(atom_dict["_atom_site.label_seq_id"], seq_id) # type
     push!(atom_dict["_atom_site.pdbx_PDB_ins_code"], inscode(at) == ' ' ? "?" : string(inscode(at)))
-    push!(atom_dict["_atom_site.Cartn_x"], string(round(x(at), 3)))
-    push!(atom_dict["_atom_site.Cartn_y"], string(round(y(at), 3)))
-    push!(atom_dict["_atom_site.Cartn_z"], string(round(z(at), 3)))
-    push!(atom_dict["_atom_site.occupancy"], string(occupancy(at)))
-    push!(atom_dict["_atom_site.B_iso_or_equiv"], string(tempfactor(at)))
+    push!(atom_dict["_atom_site.Cartn_x"], fmt(coordspec, round(x(at), 3)))
+    push!(atom_dict["_atom_site.Cartn_y"], fmt(coordspec, round(y(at), 3)))
+    push!(atom_dict["_atom_site.Cartn_z"], fmt(coordspec, round(z(at), 3)))
+    push!(atom_dict["_atom_site.occupancy"], fmt(floatspec, occupancy(at)))
+    push!(atom_dict["_atom_site.B_iso_or_equiv"], fmt(floatspec, tempfactor(at)))
 
     #atom_dict["_atom_site.auth_seq_id"].append(resseq)
 

--- a/src/mmcif.jl
+++ b/src/mmcif.jl
@@ -1,0 +1,473 @@
+export
+    MMCIFDict,
+    writemmcif
+
+# mmCIF special characters
+const quotechars = Set(['\'', '\"'])
+const whitespacechars = Set([' ', '\t'])
+const missingvals = Set([".", "?"])
+const specialchars = Set(['_', '#', '\$', '[', ']', ';'])
+const specialwords = Set(["loop_", "stop_", "global_"])
+
+"A mmCIF dictionary."
+struct MMCIFDict
+    dict::Dict{String, Union{String, Vector{String}}}
+end
+
+MMCIFDict() = MMCIFDict(Dict())
+
+Base.getindex(mmcif_dict::MMCIFDict, field::AbstractString) = mmcif_dict.dict[field]
+
+function Base.setindex!(mmcif_dict::MMCIFDict,
+                    val::Union{String, Vector{String}},
+                    field::AbstractString)
+    mmcif_dict.dict[field] = val
+    return mmcif_dict
+end
+
+Base.keys(mmcif_dict::MMCIFDict) = keys(mmcif_dict.dict)
+Base.values(mmcif_dict::MMCIFDict) = values(mmcif_dict.dict)
+Base.haskey(mmcif_dict::MMCIFDict, key) = haskey(mmcif_dict.dict, key)
+
+function Base.show(io::IO, mmcif_dict::MMCIFDict)
+    print("mmCIF dictionary with $(length(keys(mmcif_dict))) fields")
+end
+
+
+function splitline(s::AbstractString)
+    # See https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax
+    #   for the syntax
+    tokens = String[]
+    in_token = false
+    # Quote character of the currently open quote, or ' ' if no quote open
+    quote_open_char = ' '
+    start_i = 0
+    for (i, c) in enumerate(s)
+        if c in whitespacechars
+            if in_token && quote_open_char == ' '
+                in_token = false
+                push!(tokens, s[start_i:i-1])
+            end
+        elseif c in quotechars
+            if quote_open_char == ' '
+                if in_token
+                    throw(ArgumentError("Opening quote in middle of word: $s"))
+                end
+                quote_open_char = c
+                in_token = true
+                start_i = i + 1
+            elseif c == quote_open_char && (i == length(s) || s[i+1] in whitespacechars)
+                quote_open_char = ' '
+                in_token = false
+                push!(tokens, s[start_i:i-1])
+            end
+        elseif c == '#' && quote_open_char == ' '
+            return tokens
+        elseif !in_token
+            in_token = true
+            start_i = i
+        end
+    end
+    if in_token
+        push!(tokens, s[start_i:end])
+    end
+    if quote_open_char != ' '
+        throw(ArgumentError("Line ended with quote open: $s"))
+    end
+    return tokens
+end
+
+function tokenizecif(f::IOStream)
+    tokens = String[]
+    for line in eachline(f)
+        if startswith(line, "#")
+            continue
+        elseif startswith(line, ";")
+            token_buffer = [rstrip(line[2:end])]
+            for inner_line in eachline(f)
+                inner_strip = rstrip(inner_line)
+                if inner_strip == ";"
+                    break
+                end
+                push!(token_buffer, inner_strip)
+            end
+            push!(tokens, join(token_buffer, "\n"))
+        else
+            append!(tokens, splitline(line))
+        end
+    end
+    return tokens
+end
+
+
+function MMCIFDict(mmcif_filepath::AbstractString)
+    open(mmcif_filepath) do f
+        MMCIFDict(f)
+    end
+end
+
+function MMCIFDict(f::IO)
+    mmcif_dict = MMCIFDict()
+    tokens = tokenizecif(f)
+    token = first(tokens)
+    mmcif_dict[token[1:5]] = token[6:end]
+    key = ""
+    keys = String[]
+    loop_flag = false
+    i = 0
+    n = 0
+    for token in tokens[2:end]
+        if lowercase(token) == "loop_"
+            loop_flag = true
+            keys = String[]
+            i = 0
+            n = 0
+            continue
+        elseif loop_flag
+            # The second condition checks we are in the first column
+            # Some mmCIF files (e.g. 4q9r) have values in later columns
+            #   starting with an underscore and we don't want to read
+            #   these as keys
+            if startswith(token, "_") && (n == 0 || i % n == 0)
+                if i > 0
+                    loop_flag = false
+                else
+                    mmcif_dict[token] = String[]
+                    push!(keys, token)
+                    n += 1
+                    continue
+                end
+            else
+                push!(mmcif_dict[keys[i % n + 1]], token)
+                i += 1
+                continue
+            end
+        end
+        if key == ""
+            key = token
+        else
+            mmcif_dict[key] = token
+            key = ""
+        end
+    end
+    return mmcif_dict
+end
+
+
+function Base.read(input::IO,
+            ::Type{MMCIF};
+            structure_name::AbstractString="",
+            remove_disorder::Bool=false,
+            read_std_atoms::Bool=true,
+            read_het_atoms::Bool=true)
+    mmcif_dict = MMCIFDict(input)
+    # Define ProteinStructure and add to it incrementally
+    struc = ProteinStructure(structure_name)
+    if haskey(mmcif_dict, "_atom_site.id")
+        for i in 1:length(mmcif_dict["_atom_site.id"])
+            if (read_std_atoms && mmcif_dict["_atom_site.group_PDB"][i] == "ATOM") ||
+                    (read_het_atoms && mmcif_dict["_atom_site.group_PDB"][i] == "HETATM")
+                model_n = parse(Int, mmcif_dict["_atom_site.pdbx_PDB_model_num"][i])
+                # Create model if required
+                if !haskey(models(struc), model_n)
+                    struc[model_n] = Model(model_n, struc)
+                end
+                unsafe_addatomtomodel!(
+                    struc[model_n],
+                    AtomRecord(mmcif_dict, i),
+                    remove_disorder=remove_disorder)
+            end
+        end
+        # Generate lists for iteration
+        fixlists!(struc)
+    end
+    return struc
+end
+
+AtomRecord(d::MMCIFDict, i::Integer) = AtomRecord(
+    d["_atom_site.group_PDB"][i] == "HETATM",
+    parse(Int, d["_atom_site.id"][i]),
+    d["_atom_site.auth_atom_id"][i],
+    d["_atom_site.label_alt_id"][i] in missingvals ? ' ' : d["_atom_site.label_alt_id"][i][1],
+    d["_atom_site.auth_comp_id"][i],
+    d["_atom_site.auth_asym_id"][i][1],
+    parse(Int, d["_atom_site.auth_seq_id"][i]),
+    d["_atom_site.pdbx_PDB_ins_code"][i] in missingvals ? ' ' : d["_atom_site.pdbx_PDB_ins_code"][i][1],
+    [
+        parse(Float64, d["_atom_site.Cartn_x"][i]),
+        parse(Float64, d["_atom_site.Cartn_y"][i]),
+        parse(Float64, d["_atom_site.Cartn_z"][i])
+    ],
+    d["_atom_site.occupancy"][i] in missingvals ? 1.0 : parse(Float64, d["_atom_site.occupancy"][i]),
+    d["_atom_site.B_iso_or_equiv"][i] in missingvals ? 0.0 : parse(Float64, d["_atom_site.B_iso_or_equiv"][i]),
+    d["_atom_site.type_symbol"][i] in missingvals ? "  " : d["_atom_site.type_symbol"][i],
+    d["_atom_site.pdbx_formal_charge"][i] in missingvals ? "  " : d["_atom_site.pdbx_formal_charge"][i],
+)
+
+# If certain entries should have a certain order of keys, that is specified here
+mmciforder = Dict(
+    "_atom_site"=> [
+        "group_PDB",
+        "id",
+        "type_symbol",
+        "label_atom_id",
+        "label_alt_id",
+        "label_comp_id",
+        "label_asym_id",
+        "label_entity_id",
+        "label_seq_id",
+        "pdbx_PDB_ins_code",
+        "Cartn_x",
+        "Cartn_y",
+        "Cartn_z",
+        "occupancy",
+        "B_iso_or_equiv",
+        "pdbx_formal_charge",
+        "auth_seq_id",
+        "auth_comp_id",
+        "auth_asym_id",
+        "auth_atom_id",
+        "pdbx_PDB_model_num",
+    ]
+)
+
+function formatmmcifcol(val::AbstractString, col_width::Integer=length(val))
+    # Format a mmCIF data value by enclosing with quotes or semicolon lines
+    #   where appropriate. See
+    #   https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax for syntax.
+
+    # If there is a newline or quotes cannot be contained, use semicolon
+    #   and newline construct
+    if requiresnewline(val)
+        return "\n;$val\n;\n"
+    elseif requiresquote(val)
+        # Choose quote character
+        if contains(val, "' ")
+            return rpad("\"$val\"", col_width)
+        else
+            return rpad("'$val'", col_width)
+        end
+    # Safe to not quote
+    # Numbers must not be quoted
+    else
+        return rpad(val, col_width)
+    end
+end
+
+function requiresnewline(val)
+    return contains(val, "\n") || (contains(val, "' ") && contains(val, "\" "))
+end
+
+function requiresquote(val)
+    return contains(val, " ") || contains(val, "'") || contains(val, "\"") ||
+        val[1] in specialchars || startswith(lowercase(val), "data_") ||
+        startswith(lowercase(val), "save_") || val in specialwords
+end
+
+function entitylabel(entity_id::Integer)
+    # Convert a positive integer into a chain ID
+    # Goes A to Z, then AA to ZA, AB to ZB etc
+    # This is in line with existing mmCIF files
+    div = entity_id
+    out = ""
+    while div > 0
+        mod = (div - 1) % 26
+        out = "$out$(Char(65+mod))"
+        div = Int(floor((div - mod) / 26))
+    end
+    return out
+end
+
+function writemmcif(filepath::AbstractString, mmcif_dict::MMCIFDict)
+    open(filepath, "w") do output
+        writemmcif(output, mmcif_dict)
+    end
+end
+
+function writemmcif(output::IOStream, mmcif_dict::MMCIFDict)
+    # Form dictionary where key is first part of mmCIF key and value is list
+    #   of corresponding second parts
+    key_lists = Dict{String, Vector{String}}()
+    data_val = ""
+    for key in keys(mmcif_dict)
+        if lowercase(key) == "data_"
+            data_val = mmcif_dict[key]
+        else
+            s = split(key, "\.")
+            if length(s) == 2
+                if s[1] in keys(key_lists)
+                    push!(key_lists[s[1]], s[2])
+                else
+                    key_lists[s[1]] = [s[2]]
+                end
+            else
+                throw(ArgumentError("Invalid key in mmCIF dictionary: $key"))
+            end
+        end
+    end
+
+    # Re-order lists if an order has been specified
+    # Not all elements from the specified order are necessarily present
+    for (key, key_list) in key_lists
+        if key in keys(mmciforder)
+            inds = Int[]
+            for i in key_list
+                f = findfirst(mmciforder[key], i)
+                if f == 0
+                    # Unrecognised key - add at end
+                    f = length(mmciforder[key]) + 1
+                end
+                push!(inds, f)
+            end
+            key_lists[key] = [k for (_, k) in sort(collect(zip(inds, key_list)))]
+        end
+    end
+
+    # Write out top data_ line
+    if data_val != ""
+        println(output, "data_$data_val\n#")
+    end
+
+    for (key, key_list) in key_lists
+        # Pick a sample mmCIF value, which can be a list or a single value
+        sample_val = mmcif_dict["$key.$(key_list[1])"]
+        n_vals = length(sample_val)
+        # Check the mmCIF dictionary has consistent list sizes
+        for i in key_list
+            val = mmcif_dict["$key.$i"]
+            if (isa(sample_val, Array) && (isa(val, String) || length(val) != n_vals)) || (isa(sample_val, String) && isa(val, Array))
+                throw(ArgumentError("Inconsistent list sizes in mmCIF dictionary: $key.$i"))
+            end
+        end
+        # If the value is a single value, write as key-value pairs
+        if isa(sample_val, String)
+            m = 0
+            # Find the maximum key length
+            for i in key_list
+                if length(i) > m
+                    m = length(i)
+                end
+            end
+            for i in key_list
+                println(output, "$(rpad("$key.$i", length(key)+m+4))$(formatmmcifcol(mmcif_dict["$key.$i"]))")
+            end
+        # If the value is a list, write as keys then a value table
+        elseif isa(sample_val, Array)
+            println(output, "loop_")
+            col_widths = Dict{String, Int}()
+            # Write keys and find max widths for each set of values
+            for i in key_list
+                println(output, "$key.$i")
+                col_widths[i] = 0
+                for val in mmcif_dict["$key.$i"]
+                    len_val = length(val)
+                    # If the value requires quoting it will add 2 characters
+                    if requiresquote(val) && !requiresnewline(val)
+                        len_val += 2
+                    end
+                    if len_val > col_widths[i]
+                        col_widths[i] = len_val
+                    end
+                end
+            end
+            # Technically the max of the sum of the column widths is 2048
+
+            # Write the values as rows
+            for i in 1:n_vals
+                for col in key_list
+                    print(output, formatmmcifcol(mmcif_dict["$key.$col"][i], col_widths[col]+1))
+                end
+                println(output)
+            end
+        else
+            throw(ArgumentError("Invalid type in mmCIF dictionary: $(typeof(sample_val))"))
+        end
+        println(output, "#")
+    end
+end
+
+function writemmcif(filepath::AbstractString,
+                el::StructuralElementOrList,
+                atom_selectors::Function...)
+    open(filepath, "w") do output
+        writemmcif(output, el, atom_selectors...)
+    end
+end
+
+function writemmcif(output::IO,
+                el::Union{Model, Chain, AbstractResidue, Vector{Chain},
+                    Vector{AbstractResidue}, Vector{Residue}, Vector{DisorderedResidue}},
+                atom_selectors::Function...)
+    written_fields = [
+        "_atom_site.group_PDB",
+        "_atom_site.id",
+        "_atom_site.type_symbol",
+        "_atom_site.label_atom_id",
+        "_atom_site.label_alt_id",
+        "_atom_site.label_comp_id",
+        #"_atom_site.label_asym_id",
+        #"_atom_site.label_entity_id",
+        #"_atom_site.label_seq_id",
+        "_atom_site.pdbx_PDB_ins_code",
+        "_atom_site.Cartn_x",
+        "_atom_site.Cartn_y",
+        "_atom_site.Cartn_z",
+        "_atom_site.occupancy",
+        "_atom_site.B_iso_or_equiv",
+        #"_atom_site.auth_seq_id",
+        "_atom_site.auth_asym_id",
+        "_atom_site.pdbx_PDB_model_num",
+    ]
+    # differences to above are pdbx_formal_charge auth_comp_id auth_atom_id
+    # can this list be eliminated?
+    atom_dict = Dict([i=> String[] for i in written_fields])
+
+    # Collect residues then expand out disordered residues
+    for res in collectresidues(el)
+        model_n = string(modelnumber(res))
+        chain_id = string(chainid(res))
+        res_n = string(resnumber(res))
+        het = ishetero(res) ? "HETATM" : "ATOM"
+        if isa(res, Residue)
+            res_name = resname(res)
+            for at in collectatoms(res, atom_selectors...)
+                appendatom!(atom_dict, at, model_n, chain_id, res_n, res_name, het)
+            end
+        else
+            for res_name in resnames(res)
+                for at in collectatoms(disorderedres(res, res_name), atom_selectors...)
+                    appendatom!(atom_dict, at, model_n, chain_id, res_n, res_name, het)
+                end
+            end
+        end
+    end
+    return writemmcif(output, MMCIFDict(atom_dict))
+end
+
+function appendatom!(atom_dict, at, model_n, chain_id, res_n, res_name, het) # add entity_id? and seq_id
+    push!(atom_dict["_atom_site.group_PDB"], het)
+    push!(atom_dict["_atom_site.id"], string(serial(at)))
+    push!(atom_dict["_atom_site.type_symbol"], length(element(at)) == 0 ? "?" : element(at))
+    push!(atom_dict["_atom_site.label_atom_id"], atomname(at))
+    push!(atom_dict["_atom_site.label_alt_id"], altlocid(at) == ' ' ? "." : string(altlocid(at)))
+    push!(atom_dict["_atom_site.label_comp_id"], res_name)
+
+    #push!(atom_dict["_atom_site.label_asym_id"], entitylabel(entity_id))
+
+    # The entity ID should be the same for similar chains
+    # However this is non-trivial to calculate so we write "?"
+    #atom_dict["_atom_site.label_entity_id"].append("?")
+
+    #push!(atom_dict["_atom_site.label_seq_id"], seq_id) # type
+    push!(atom_dict["_atom_site.pdbx_PDB_ins_code"], inscode(at) == ' ' ? "?" : string(inscode(at)))
+    push!(atom_dict["_atom_site.Cartn_x"], string(round(x(at), 3)))
+    push!(atom_dict["_atom_site.Cartn_y"], string(round(y(at), 3)))
+    push!(atom_dict["_atom_site.Cartn_z"], string(round(z(at), 3)))
+    push!(atom_dict["_atom_site.occupancy"], string(occupancy(at)))
+    push!(atom_dict["_atom_site.B_iso_or_equiv"], string(tempfactor(at)))
+
+    #atom_dict["_atom_site.auth_seq_id"].append(resseq)
+
+    push!(atom_dict["_atom_site.auth_asym_id"], chain_id)
+    push!(atom_dict["_atom_site.pdbx_PDB_model_num"], model_n)
+end

--- a/src/model.jl
+++ b/src/model.jl
@@ -119,7 +119,7 @@ end
 
 
 """
-A residue (amino acid) or other molecule - either a`Residue` or a
+A residue (amino acid) or other molecule - either a `Residue` or a
 `DisorderedResidue`.
 """
 abstract type AbstractResidue <: StructuralElement end

--- a/src/pdb.jl
+++ b/src/pdb.jl
@@ -673,6 +673,10 @@ function spaceatomname(at::Atom)
 end
 
 
+# Decimal places to format output to
+const coordspec = FormatSpec(".3f")
+const floatspec = FormatSpec(".2f")
+
 """
 Form a Protein Data Bank (PDB) format ATOM or HETATM record from an `Atom` or
 `AtomRecord`.
@@ -690,12 +694,12 @@ function pdbline(at::Atom)
             string(inscode(at)) *
             "   " *
             # This will throw an error for large coordinate values, e.g. -1000.123
-            spacestring(round(x(at), 3), 8) *
-            spacestring(round(y(at), 3), 8) *
-            spacestring(round(z(at), 3), 8) *
-            spacestring(round(occupancy(at), 2), 6) *
+            spacestring(fmt(coordspec, round(x(at), 3)), 8) *
+            spacestring(fmt(coordspec, round(y(at), 3)), 8) *
+            spacestring(fmt(coordspec, round(z(at), 3)), 8) *
+            spacestring(fmt(floatspec, round(occupancy(at), 2)), 6) *
             # This will throw an error for large temp facs, e.g. 1000.12
-            spacestring(round(tempfactor(at), 2), 6) *
+            spacestring(fmt(floatspec, round(tempfactor(at), 2)), 6) *
             "          " *
             spacestring(element(at), 2) *
             spacestring(charge(at), 2)
@@ -714,12 +718,12 @@ function pdbline(at_rec::AtomRecord)
             string(at_rec.ins_code) *
             "   " *
             # This will throw an error for large coordinate values, e.g. -1000.123
-            spacestring(round(at_rec.coords[1], 3), 8) *
-            spacestring(round(at_rec.coords[2], 3), 8) *
-            spacestring(round(at_rec.coords[3], 3), 8) *
-            spacestring(round(at_rec.occupancy, 2), 6) *
+            spacestring(fmt(coordspec, round(at_rec.coords[1], 3)), 8) *
+            spacestring(fmt(coordspec, round(at_rec.coords[2], 3)), 8) *
+            spacestring(fmt(coordspec, round(at_rec.coords[3], 3)), 8) *
+            spacestring(fmt(floatspec, round(at_rec.occupancy, 2)), 6) *
             # This will throw an error for large temp facs, e.g. 1000.12
-            spacestring(round(at_rec.temp_factor, 2), 6) *
+            spacestring(fmt(floatspec, round(at_rec.temp_factor, 2)), 6) *
             "          " *
             spacestring(at_rec.element, 2) *
             spacestring(at_rec.charge, 2)

--- a/src/pdb.jl
+++ b/src/pdb.jl
@@ -480,11 +480,11 @@ function Base.read(input::IO,
 end
 
 function Base.read(filepath::AbstractString,
-            ::Type{PDB};
+            t::Type{T};
             structure_name::AbstractString=splitdir(filepath)[2],
-            kwargs...)
+            kwargs...) where {T <: Union{PDB, MMCIF}}
     open(filepath, "r") do input
-        read(input, PDB; structure_name=structure_name, kwargs...)
+        read(input, t; structure_name=structure_name, kwargs...)
     end
 end
 

--- a/src/pdb.jl
+++ b/src/pdb.jl
@@ -483,7 +483,7 @@ function Base.read(filepath::AbstractString,
             t::Type{T};
             structure_name::AbstractString=splitdir(filepath)[2],
             kwargs...) where {T <: Union{PDB, MMCIF}}
-    open(filepath, "r") do input
+    open(filepath) do input
         read(input, t; structure_name=structure_name, kwargs...)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ using BioStructures:
     checkchainerror,
     splitline,
     tokenizecif,
+    tokenizecifstructure,
     formatmmcifcol,
     requiresnewline,
     requiresquote
@@ -862,7 +863,7 @@ end
     @test tempfactor(struc['A'][167]["NE"]) == 23.32
 
     # Test parsing from stream
-    open(testfilepath("PDB", "1AKE.pdb"), "r") do file
+    open(testfilepath("PDB", "1AKE.pdb")) do file
         struc = read(file, PDB)
         @test countatoms(struc) == 3804
         @test countresidues(struc) == 808
@@ -1578,11 +1579,19 @@ end
     @test_throws ArgumentError splitline("foo b'ar'")
 
 
-    # Test tokenizecif
+    # Test tokenizecif and tokenizecifstructure
     open(testfilepath("mmCIF", "1AKE.cif")) do f
         tokens = tokenizecif(f)
         @test length(tokens) == 93983
         @test tokens[90000] == "HOH"
+    end
+
+    open(testfilepath("mmCIF", "1AKE.cif")) do f
+        tokens = tokenizecifstructure(f)
+        @test length(tokens) == 80158
+        @test tokens[1] == "loop_"
+        @test tokens[10] == "_atom_site.label_seq_id"
+        @test tokens[80089] == "77.69"
     end
 
 
@@ -1664,7 +1673,7 @@ end
 
 
     # Test parsing from stream
-    open(testfilepath("mmCIF", "1AKE.cif"), "r") do file
+    open(testfilepath("mmCIF", "1AKE.cif")) do file
         struc = read(file, MMCIF)
         @test countatoms(struc) == 3804
         @test countresidues(struc) == 808
@@ -1946,6 +1955,13 @@ end
     @test altlocid(disorderedres(struc_written['A'][10], "GLY")["O"]) == 'B'
     @test countatoms(struc_written['A'][10]) == 6
     @test countatoms(struc_written['A'][16]) == 11
+
+
+    # Test writing multi-character chain IDs
+    struc = read(IOBuffer(multichar_str), MMCIF)
+    writemmcif(temp_filename, struc)
+    struc_back = read(temp_filename, MMCIF)
+    @test chainids(struc_back) == ["A1", "A2"]
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1512,8 +1512,14 @@ end
         ?
         """
     dic = MMCIFDict(IOBuffer(quote_str))
-    @test dic["_struct_conf.pdbx_PDB_helix_id"] == ["A", "A'", "B", "C", "B'", "D", "E", "C'", "F", "G", "H", "D'", "E'", "A'\"", "BC", "CD", "DE"]
-    @test dic["_struct_conf.details"] == ["?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "TYPE I'", "TYPE I", "TYPE I (H-BOND O65-N69)", "TYPE II'"]
+    @test dic["_struct_conf.pdbx_PDB_helix_id"] == [
+        "A", "A'", "B", "C", "B'", "D", "E", "C'",
+        "F", "G", "H", "D'", "E'", "A'\"", "BC", "CD", "DE"
+    ]
+    @test dic["_struct_conf.details"] == [
+        "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?", "?",
+        "TYPE I'", "TYPE I", "TYPE I (H-BOND O65-N69)", "TYPE II'"
+    ]
 
     underscore_str = """
         data_4Q9R
@@ -1529,7 +1535,11 @@ end
         """
     dic = MMCIFDict(IOBuffer(underscore_str))
     @test length(keys(dic)) == 5
-    @test dic["_pdbx_audit_revision_item.item"] == ["_atom_site.B_iso_or_equiv", "_atom_site.Cartn_x", "_atom_site.Cartn_y", "_atom_site.Cartn_z"]
+    @test dic["_pdbx_audit_revision_item.item"] == [
+        "_atom_site.B_iso_or_equiv", "_atom_site.Cartn_x",
+        "_atom_site.Cartn_y", "_atom_site.Cartn_z"
+    ]
+
 
     # Test splitline
     @test splitline("foo bar") == ["foo", "bar"]
@@ -1545,12 +1555,14 @@ end
     @test_throws ArgumentError splitline("foo \"bar'")
     @test_throws ArgumentError splitline("foo b'ar'")
 
+
     # Test tokenizecif
     open(testfilepath("mmCIF", "1AKE.cif")) do f
         tokens = tokenizecif(f)
         @test length(tokens) == 93983
         @test tokens[90000] == "HOH"
     end
+
 
     # Test AtomRecord
     at_rec = AtomRecord(MMCIFDict(testfilepath("mmCIF", "1AKE.cif")), 5)
@@ -1568,6 +1580,7 @@ end
     @test at_rec.temp_factor == 38.06
     @test at_rec.element == "C"
     @test at_rec.charge == "  "
+
 
     # Test parsing 1AKE
     struc = read(testfilepath("mmCIF", "1AKE.cif"), MMCIF)
@@ -1598,6 +1611,7 @@ end
     @test length(ats) == 8
     @test atomname.(ats) == ["N", "CA", "C", "O", "CB", "CG1", "CG2", "CD1"]
 
+
     # Test parsing options
     struc = read(testfilepath("mmCIF", "1AKE.cif"), MMCIF, structure_name="New name")
     @test structurename(struc) == "New name"
@@ -1626,12 +1640,14 @@ end
     @test sum(isdisorderedatom.(collectatoms(struc))) == 0
     @test tempfactor(struc['A'][167]["NE"]) == 23.32
 
+
     # Test parsing from stream
     open(testfilepath("mmCIF", "1AKE.cif"), "r") do file
         struc = read(file, MMCIF)
         @test countatoms(struc) == 3804
         @test countresidues(struc) == 808
     end
+
 
     # Test parsing 1EN2
     struc = read(testfilepath("mmCIF", "1EN2.cif"), MMCIF)
@@ -1665,6 +1681,7 @@ end
     @test isa(res, Vector{DisorderedResidue})
     @test resnumber(res[1]) == 10
     @test countresidues(DisorderedResidue[struc['A'][16], struc['A'][10]]) == 2
+
 
     # Test parsing 1SSU
     struc = read(testfilepath("mmCIF", "1SSU.cif"), MMCIF)
@@ -1756,11 +1773,13 @@ end
     @test atomnames(struc_written[15]['A']["39"]) == [
         "N", "CA", "C", "O", "CB", "SG", "H", "HA", "HB2", "HB3"]
 
+
     # Test writing to stream
     open(temp_filename, "w") do file
         writemmcif(file, struc)
     end
     @test countlines(temp_filename) == 15145
+
 
     # Test selectors
     struc = read(testfilepath("PDB", "1AKE.pdb"), PDB)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ using BioStructures:
 fmtdir = BioCore.Testing.get_bio_fmt_specimens()
 
 # Access files in BioFmtSpecimens to test against
-testfilepath(filename::AbstractString) = joinpath(fmtdir, filename)
+testfilepath(path::AbstractString...) = joinpath(fmtdir, path...)
 
 
 @testset "PDB Handling" begin
@@ -635,7 +635,7 @@ end
 
 
     # Test sequence extraction
-    struc = read(testfilepath("PDB/1AKE.pdb"), PDB)
+    struc = read(testfilepath("PDB", "1AKE.pdb"), PDB)
     seq = AminoAcidSequence(struc['B'])
     @test seq == AminoAcidSequence(
         "MRIILLGAPGAGKGTQAQFIMEKYGIPQISTGDMLRAAVKSGSELGKQAKDIMDAGKLVTDELVIALVKERIAQEDCRNG" *
@@ -738,7 +738,7 @@ end
 
 
     # Test parsing 1AKE (multiple chains, disordered atoms)
-    struc = read(testfilepath("PDB/1AKE.pdb"), PDB)
+    struc = read(testfilepath("PDB", "1AKE.pdb"), PDB)
     @test structurename(struc) == "1AKE.pdb"
     @test countmodels(struc) == 1
     @test modelnumbers(struc) == [1]
@@ -826,33 +826,33 @@ end
 
 
     # Test parsing options
-    struc = read(testfilepath("PDB/1AKE.pdb"), PDB, structure_name="New name")
+    struc = read(testfilepath("PDB", "1AKE.pdb"), PDB, structure_name="New name")
     @test structurename(struc) == "New name"
     @test countatoms(struc) == 3804
 
-    struc = read(testfilepath("PDB/1AKE.pdb"), PDB, read_het_atoms=false)
+    struc = read(testfilepath("PDB", "1AKE.pdb"), PDB, read_het_atoms=false)
     @test countatoms(struc) == 3312
     @test serial(collectatoms(struc)[2000]) == 2006
     @test sum(map(ishetero, collectatoms(struc))) == 0
 
-    struc = read(testfilepath("PDB/1AKE.pdb"), PDB, read_std_atoms=false)
+    struc = read(testfilepath("PDB", "1AKE.pdb"), PDB, read_std_atoms=false)
     @test countatoms(struc) == 492
     @test serial(collectatoms(struc)[400]) == 3726
     @test sum(map(ishetero, collectatoms(struc))) == 492
 
-    struc = read(testfilepath("PDB/1AKE.pdb"), PDB, read_het_atoms=false, read_std_atoms=false)
+    struc = read(testfilepath("PDB", "1AKE.pdb"), PDB, read_het_atoms=false, read_std_atoms=false)
     @test countatoms(struc) == 0
     @test countresidues(struc) == 0
     @test countchains(struc) == 0
     @test countmodels(struc) == 0
 
-    struc = read(testfilepath("PDB/1AKE.pdb"), PDB, remove_disorder=true)
+    struc = read(testfilepath("PDB", "1AKE.pdb"), PDB, remove_disorder=true)
     @test countatoms(struc) == 3804
     @test sum(map(isdisorderedatom, collectatoms(struc))) == 0
     @test tempfactor(struc['A'][167]["NE"]) == 23.32
 
     # Test parsing from stream
-    open(testfilepath("PDB/1AKE.pdb"), "r") do file
+    open(testfilepath("PDB", "1AKE.pdb"), "r") do file
         struc = read(file, PDB)
         @test countatoms(struc) == 3804
         @test countresidues(struc) == 808
@@ -860,7 +860,7 @@ end
 
 
     # Test parsing 1EN2 (disordered residue)
-    struc = read(testfilepath("PDB/1EN2.pdb"), PDB)
+    struc = read(testfilepath("PDB", "1EN2.pdb"), PDB)
     @test modelnumbers(struc) == [1]
     @test chainids(struc[1]) == ['A']
     @test serial(struc['A'][48]["CA"]) == 394
@@ -895,7 +895,7 @@ end
 
 
     # Test parsing 1SSU (multiple models)
-    struc = read(testfilepath("PDB/1SSU.pdb"), PDB)
+    struc = read(testfilepath("PDB", "1SSU.pdb"), PDB)
     # Test countmodels
     @test countmodels(struc) == 20
     @test modelnumbers(struc) == collect(1:20)
@@ -930,7 +930,7 @@ end
 
 
     # Test collectatoms
-    struc = read(testfilepath("PDB/1AKE.pdb"), PDB)
+    struc = read(testfilepath("PDB", "1AKE.pdb"), PDB)
     ats = collectatoms(struc)
     @test length(ats) == 3804
     @test isa(ats, Vector{AbstractAtom})
@@ -1152,7 +1152,7 @@ end
 
 
     # Test collectmodels
-    struc_1SSU = read(testfilepath("PDB/1SSU.pdb"), PDB)
+    struc_1SSU = read(testfilepath("PDB", "1SSU.pdb"), PDB)
     mods = collectmodels(struc_1SSU)
     @test length(mods) == 20
     @test isa(mods, Vector{Model})
@@ -1218,15 +1218,15 @@ end
     error = PDBParseError("message", 10, "line")
     showerror(DevNull, error)
     # Missing coordinate (blank string)
-    @test_throws PDBParseError read(testfilepath("PDB/1AKE_err_a.pdb"), PDB)
+    @test_throws PDBParseError read(testfilepath("PDB", "1AKE_err_a.pdb"), PDB)
     # Missing chain ID (line ends early)
-    @test_throws PDBParseError read(testfilepath("PDB/1AKE_err_b.pdb"), PDB)
+    @test_throws PDBParseError read(testfilepath("PDB", "1AKE_err_b.pdb"), PDB)
     # Bad MODEL record
-    @test_throws PDBParseError read(testfilepath("PDB/1SSU_err.pdb"), PDB)
+    @test_throws PDBParseError read(testfilepath("PDB", "1SSU_err.pdb"), PDB)
     # Duplicate atom names in same residue
-    @test_throws ErrorException read(testfilepath("PDB/1AKE_err_c.pdb"), PDB)
+    @test_throws ErrorException read(testfilepath("PDB", "1AKE_err_c.pdb"), PDB)
     # Non-existent file
-    @test_throws SystemError read(testfilepath("PDB/non_existent_file.pdb"), PDB)
+    @test_throws SystemError read(testfilepath("PDB", "non_existent_file.pdb"), PDB)
 end
 
 
@@ -1295,7 +1295,7 @@ end
         return counter
     end
 
-    struc = read(testfilepath("PDB/1SSU.pdb"), PDB)
+    struc = read(testfilepath("PDB", "1SSU.pdb"), PDB)
     # All writing is done to one temporary file which is removed at the end
     temp_filename = tempname()
     writepdb(temp_filename, struc)
@@ -1323,7 +1323,7 @@ end
 
 
     # Test selectors
-    struc = read(testfilepath("PDB/1AKE.pdb"), PDB)
+    struc = read(testfilepath("PDB", "1AKE.pdb"), PDB)
     writepdb(temp_filename, struc, heteroselector)
     @test countlines(temp_filename) == 499
     struc_written = read(temp_filename, PDB)
@@ -1390,7 +1390,7 @@ end
 
 
     # Test multiple model writing
-    struc = read(testfilepath("PDB/1SSU.pdb"), PDB)
+    struc = read(testfilepath("PDB", "1SSU.pdb"), PDB)
     writepdb(temp_filename, Model[struc[10], struc[5]])
     @test countlines(temp_filename) == 1516
     struc_written = read(temp_filename, PDB)
@@ -1402,7 +1402,7 @@ end
 
 
     # Test disordered residue writing
-    struc = read(testfilepath("PDB/1EN2.pdb"), PDB)
+    struc = read(testfilepath("PDB", "1EN2.pdb"), PDB)
     writepdb(temp_filename, struc)
     @test countlines(temp_filename) == 819
     struc_written = read(temp_filename, PDB)
@@ -1438,7 +1438,7 @@ end
 @testset "mmCIF" begin
     # Test mmCIF dictionary
     dic = MMCIFDict()
-    dic = MMCIFDict(testfilepath("mmCIF/1AKE.cif"))
+    dic = MMCIFDict(testfilepath("mmCIF", "1AKE.cif"))
     @test dic["_pdbx_database_status.recvd_initial_deposition_date"] == "1991-11-08"
     @test dic["_audit_author.name"] == ["Mueller, C.W.", "Schulz, G.E."]
     @test length(dic["_atom_site.group_PDB"]) == 3816
@@ -1476,14 +1476,14 @@ end
     @test_throws ArgumentError splitline("foo b'ar'")
 
     # Test tokenizecif
-    open(testfilepath("mmCIF/1AKE.cif")) do f
+    open(testfilepath("mmCIF", "1AKE.cif")) do f
         tokens = tokenizecif(f)
         @test length(tokens) == 93983
         @test tokens[90000] == "HOH"
     end
 
     # Test AtomRecord
-    at_rec = AtomRecord(MMCIFDict(testfilepath("mmCIF/1AKE.cif")), 5)
+    at_rec = AtomRecord(MMCIFDict(testfilepath("mmCIF", "1AKE.cif")), 5)
     show(DevNull, at_rec)
     @test !at_rec.het_atom
     @test at_rec.serial == 5
@@ -1520,7 +1520,7 @@ end
     @test cs[2] == 2.0
     @test cs[3] == 3.0
 
-    struc_1AKE = read(testfilepath("PDB/1AKE.pdb"), PDB)
+    struc_1AKE = read(testfilepath("PDB", "1AKE.pdb"), PDB)
     cs = coordarray(struc_1AKE)
     @test size(cs) == (3,3804)
     @test cs[1,3787] == 20.135
@@ -1559,7 +1559,7 @@ end
     ]
     @test_throws ArgumentError rmsd(cs_one, cs_two)
 
-    struc_1SSU = read(testfilepath("PDB/1SSU.pdb"), PDB)
+    struc_1SSU = read(testfilepath("PDB", "1SSU.pdb"), PDB)
     @test isapprox(rmsd(struc_1SSU[1], struc_1SSU[2], calphaselector), 4.1821925809691889)
     @test isapprox(rmsd(struc_1SSU[5], struc_1SSU[6], backboneselector), 5.2878196391279939)
     @test_throws ArgumentError rmsd(struc_1SSU[1]['A'][8], struc_1SSU[1]['A'][9])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1238,6 +1238,12 @@ end
     @test_throws ErrorException read(testfilepath("PDB", "1AKE_err_c.pdb"), PDB)
     # Non-existent file
     @test_throws SystemError read(testfilepath("PDB", "non_existent_file.pdb"), PDB)
+
+
+    # Test parsing empty file
+    struc = read(IOBuffer(""), PDB)
+    @test isa(struc, ProteinStructure)
+    @test countmodels(struc) == 0
 end
 
 
@@ -1595,6 +1601,13 @@ end
     end
 
 
+    # Test parsing empty file
+    dic = MMCIFDict(IOBuffer(""))
+    @test isa(dic, MMCIFDict)
+    @test length(keys(dic)) == 0
+    @test length(values(dic)) == 0
+
+
     # Test AtomRecord
     at_rec = AtomRecord(MMCIFDict(testfilepath("mmCIF", "1AKE.cif")), 5)
     show(DevNull, at_rec)
@@ -1788,6 +1801,12 @@ end
     # Test files that should not parse
     @test_throws Exception read(testfilepath("mmCIF", "1AKE_err.cif"), MMCIF)
     @test_throws ErrorException read(testfilepath("mmCIF", "1EN2_err.cif"), MMCIF)
+
+
+    # Test parsing empty file
+    struc = read(IOBuffer(""), MMCIF)
+    @test isa(struc, ProteinStructure)
+    @test countmodels(struc) == 0
 
 
     # Test formatting

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,13 +22,19 @@ using BioStructures:
     parsecharge,
     spacestring,
     coordspec,
-    floatspec
+    floatspec,
+    splitline,
+    tokenizecif,
+    formatmmcifcol,
+    requiresnewline,
+    requiresquote
 
 
 fmtdir = BioCore.Testing.get_bio_fmt_specimens()
 
-# Access a PDB file in BioFmtSpecimens
-pdbfilepath(filename::AbstractString) = joinpath(fmtdir, "PDB", filename)
+# Access files in BioFmtSpecimens to test against
+testfilepath(filename::AbstractString) = joinpath(fmtdir, filename)
+
 
 @testset "PDB Handling" begin
     @test length(pdbentrylist()) > 100000
@@ -114,6 +120,7 @@ pdbfilepath(filename::AbstractString) = joinpath(fmtdir, "PDB", filename)
     @test sum(map(isdisorderedatom, collectatoms(struc))) == 0
     @test tempfactor(struc['A'][167]["NE"]) == 23.32
 end
+
 
 @testset "Model" begin
     # Test constructors and indexing
@@ -628,7 +635,7 @@ end
 
 
     # Test sequence extraction
-    struc = read(pdbfilepath("1AKE.pdb"), PDB)
+    struc = read(testfilepath("PDB/1AKE.pdb"), PDB)
     seq = AminoAcidSequence(struc['B'])
     @test seq == AminoAcidSequence(
         "MRIILLGAPGAGKGTQAQFIMEKYGIPQISTGDMLRAAVKSGSELGKQAKDIMDAGKLVTDELVIALVKERIAQEDCRNG" *
@@ -731,7 +738,7 @@ end
 
 
     # Test parsing 1AKE (multiple chains, disordered atoms)
-    struc = read(pdbfilepath("1AKE.pdb"), PDB)
+    struc = read(testfilepath("PDB/1AKE.pdb"), PDB)
     @test structurename(struc) == "1AKE.pdb"
     @test countmodels(struc) == 1
     @test modelnumbers(struc) == [1]
@@ -819,33 +826,33 @@ end
 
 
     # Test parsing options
-    struc = read(pdbfilepath("1AKE.pdb"), PDB, structure_name="New name")
+    struc = read(testfilepath("PDB/1AKE.pdb"), PDB, structure_name="New name")
     @test structurename(struc) == "New name"
     @test countatoms(struc) == 3804
 
-    struc = read(pdbfilepath("1AKE.pdb"), PDB, read_het_atoms=false)
+    struc = read(testfilepath("PDB/1AKE.pdb"), PDB, read_het_atoms=false)
     @test countatoms(struc) == 3312
     @test serial(collectatoms(struc)[2000]) == 2006
     @test sum(map(ishetero, collectatoms(struc))) == 0
 
-    struc = read(pdbfilepath("1AKE.pdb"), PDB, read_std_atoms=false)
+    struc = read(testfilepath("PDB/1AKE.pdb"), PDB, read_std_atoms=false)
     @test countatoms(struc) == 492
     @test serial(collectatoms(struc)[400]) == 3726
     @test sum(map(ishetero, collectatoms(struc))) == 492
 
-    struc = read(pdbfilepath("1AKE.pdb"), PDB, read_het_atoms=false, read_std_atoms=false)
+    struc = read(testfilepath("PDB/1AKE.pdb"), PDB, read_het_atoms=false, read_std_atoms=false)
     @test countatoms(struc) == 0
     @test countresidues(struc) == 0
     @test countchains(struc) == 0
     @test countmodels(struc) == 0
 
-    struc = read(pdbfilepath("1AKE.pdb"), PDB, remove_disorder=true)
+    struc = read(testfilepath("PDB/1AKE.pdb"), PDB, remove_disorder=true)
     @test countatoms(struc) == 3804
     @test sum(map(isdisorderedatom, collectatoms(struc))) == 0
     @test tempfactor(struc['A'][167]["NE"]) == 23.32
 
     # Test parsing from stream
-    open(pdbfilepath("1AKE.pdb"), "r") do file
+    open(testfilepath("PDB/1AKE.pdb"), "r") do file
         struc = read(file, PDB)
         @test countatoms(struc) == 3804
         @test countresidues(struc) == 808
@@ -853,7 +860,7 @@ end
 
 
     # Test parsing 1EN2 (disordered residue)
-    struc = read(pdbfilepath("1EN2.pdb"), PDB)
+    struc = read(testfilepath("PDB/1EN2.pdb"), PDB)
     @test modelnumbers(struc) == [1]
     @test chainids(struc[1]) == ['A']
     @test serial(struc['A'][48]["CA"]) == 394
@@ -888,7 +895,7 @@ end
 
 
     # Test parsing 1SSU (multiple models)
-    struc = read(pdbfilepath("1SSU.pdb"), PDB)
+    struc = read(testfilepath("PDB/1SSU.pdb"), PDB)
     # Test countmodels
     @test countmodels(struc) == 20
     @test modelnumbers(struc) == collect(1:20)
@@ -923,7 +930,7 @@ end
 
 
     # Test collectatoms
-    struc = read(pdbfilepath("1AKE.pdb"), PDB)
+    struc = read(testfilepath("PDB/1AKE.pdb"), PDB)
     ats = collectatoms(struc)
     @test length(ats) == 3804
     @test isa(ats, Vector{AbstractAtom})
@@ -1145,7 +1152,7 @@ end
 
 
     # Test collectmodels
-    struc_1SSU = read(pdbfilepath("1SSU.pdb"), PDB)
+    struc_1SSU = read(testfilepath("PDB/1SSU.pdb"), PDB)
     mods = collectmodels(struc_1SSU)
     @test length(mods) == 20
     @test isa(mods, Vector{Model})
@@ -1211,15 +1218,15 @@ end
     error = PDBParseError("message", 10, "line")
     showerror(DevNull, error)
     # Missing coordinate (blank string)
-    @test_throws PDBParseError read(pdbfilepath("1AKE_err_a.pdb"), PDB)
+    @test_throws PDBParseError read(testfilepath("PDB/1AKE_err_a.pdb"), PDB)
     # Missing chain ID (line ends early)
-    @test_throws PDBParseError read(pdbfilepath("1AKE_err_b.pdb"), PDB)
+    @test_throws PDBParseError read(testfilepath("PDB/1AKE_err_b.pdb"), PDB)
     # Bad MODEL record
-    @test_throws PDBParseError read(pdbfilepath("1SSU_err.pdb"), PDB)
+    @test_throws PDBParseError read(testfilepath("PDB/1SSU_err.pdb"), PDB)
     # Duplicate atom names in same residue
-    @test_throws ErrorException read(pdbfilepath("1AKE_err_c.pdb"), PDB)
+    @test_throws ErrorException read(testfilepath("PDB/1AKE_err_c.pdb"), PDB)
     # Non-existent file
-    @test_throws SystemError read(pdbfilepath("non_existent_file.pdb"), PDB)
+    @test_throws SystemError read(testfilepath("PDB/non_existent_file.pdb"), PDB)
 end
 
 
@@ -1288,7 +1295,7 @@ end
         return counter
     end
 
-    struc = read(pdbfilepath("1SSU.pdb"), PDB)
+    struc = read(testfilepath("PDB/1SSU.pdb"), PDB)
     # All writing is done to one temporary file which is removed at the end
     temp_filename = tempname()
     writepdb(temp_filename, struc)
@@ -1316,7 +1323,7 @@ end
 
 
     # Test selectors
-    struc = read(pdbfilepath("1AKE.pdb"), PDB)
+    struc = read(testfilepath("PDB/1AKE.pdb"), PDB)
     writepdb(temp_filename, struc, heteroselector)
     @test countlines(temp_filename) == 499
     struc_written = read(temp_filename, PDB)
@@ -1383,7 +1390,7 @@ end
 
 
     # Test multiple model writing
-    struc = read(pdbfilepath("1SSU.pdb"), PDB)
+    struc = read(testfilepath("PDB/1SSU.pdb"), PDB)
     writepdb(temp_filename, Model[struc[10], struc[5]])
     @test countlines(temp_filename) == 1516
     struc_written = read(temp_filename, PDB)
@@ -1395,7 +1402,7 @@ end
 
 
     # Test disordered residue writing
-    struc = read(pdbfilepath("1EN2.pdb"), PDB)
+    struc = read(testfilepath("PDB/1EN2.pdb"), PDB)
     writepdb(temp_filename, struc)
     @test countlines(temp_filename) == 819
     struc_written = read(temp_filename, PDB)
@@ -1428,6 +1435,81 @@ end
 end
 
 
+@testset "mmCIF" begin
+    # Test mmCIF dictionary
+    dic = MMCIFDict()
+    dic = MMCIFDict(testfilepath("mmCIF/1AKE.cif"))
+    @test dic["_pdbx_database_status.recvd_initial_deposition_date"] == "1991-11-08"
+    @test dic["_audit_author.name"] == ["Mueller, C.W.", "Schulz, G.E."]
+    @test length(dic["_atom_site.group_PDB"]) == 3816
+    dic["_pdbx_database_status.recvd_initial_deposition_date"] = "changed"
+    @test dic["_pdbx_database_status.recvd_initial_deposition_date"] == "changed"
+    @test length(keys(dic)) == 610
+    @test length(values(dic)) == 610
+    @test haskey(dic, "_cell.entry_id")
+    @test !haskey(dic, "nokey")
+    show(DevNull, dic)
+
+    multiline_str = """\
+        data_verbatim_test
+        _test_value
+        ;First line
+            Second line
+        Third line
+        ;
+        """
+    #dic = MMCIFDict(multiline_str)
+    #@test dic["_test_value"] == "First line\n    Second line\nThird line"
+
+    # Test splitline
+    @test splitline("foo bar") == ["foo", "bar"]
+    @test splitline("  foo bar  ") == ["foo", "bar"]
+    @test splitline("'foo' bar") == ["foo", "bar"]
+    @test splitline("foo \"bar\"") == ["foo", "bar"]
+    @test splitline("foo 'bar a' b") == ["foo", "bar a", "b"]
+    @test splitline("foo 'bar'a' b") == ["foo", "bar'a", "b"]
+    @test splitline("foo \"bar' a\" b") == ["foo", "bar' a", "b"]
+    @test splitline("foo '' b") == ["foo", "", "b"]
+    @test_throws ArgumentError splitline("foo 'bar")
+    @test_throws ArgumentError splitline("foo 'ba'r  ")
+    @test_throws ArgumentError splitline("foo \"bar'")
+    @test_throws ArgumentError splitline("foo b'ar'")
+
+    # Test tokenizecif
+    open(testfilepath("mmCIF/1AKE.cif")) do f
+        tokens = tokenizecif(f)
+        @test length(tokens) == 93983
+        @test tokens[90000] == "HOH"
+    end
+
+    # Test AtomRecord
+    at_rec = AtomRecord(MMCIFDict(testfilepath("mmCIF/1AKE.cif")), 5)
+    show(DevNull, at_rec)
+    @test !at_rec.het_atom
+    @test at_rec.serial == 5
+    @test at_rec.atom_name == "CB"
+    @test at_rec.alt_loc_id == ' '
+    @test at_rec.res_name == "MET"
+    @test at_rec.chain_id == 'A'
+    @test at_rec.res_number == 1
+    @test at_rec.ins_code == ' '
+    @test at_rec.coords == [24.677, 53.310, 39.580]
+    @test at_rec.occupancy == 1.00
+    @test at_rec.temp_factor == 38.06
+    @test at_rec.element == "C"
+    @test at_rec.charge == "  "
+
+    # read
+
+
+    # formatmmcifcol, requiresnewline, requiredquote
+
+
+    # writemmcif
+
+end
+
+
 @testset "Spatial" begin
     # Test coordarray
     res = Residue("ALA", 1, ' ', false, Chain('A'))
@@ -1438,7 +1520,7 @@ end
     @test cs[2] == 2.0
     @test cs[3] == 3.0
 
-    struc_1AKE = read(pdbfilepath("1AKE.pdb"), PDB)
+    struc_1AKE = read(testfilepath("PDB/1AKE.pdb"), PDB)
     cs = coordarray(struc_1AKE)
     @test size(cs) == (3,3804)
     @test cs[1,3787] == 20.135
@@ -1477,7 +1559,7 @@ end
     ]
     @test_throws ArgumentError rmsd(cs_one, cs_two)
 
-    struc_1SSU = read(pdbfilepath("1SSU.pdb"), PDB)
+    struc_1SSU = read(testfilepath("PDB/1SSU.pdb"), PDB)
     @test isapprox(rmsd(struc_1SSU[1], struc_1SSU[2], calphaselector), 4.1821925809691889)
     @test isapprox(rmsd(struc_1SSU[5], struc_1SSU[6], backboneselector), 5.2878196391279939)
     @test_throws ArgumentError rmsd(struc_1SSU[1]['A'][8], struc_1SSU[1]['A'][9])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 module TestBioStructures
 
 using Base.Test
+using Formatting
 using BioCore
 using BioStructures
 using BioStructures:
@@ -19,7 +20,9 @@ using BioStructures:
     parsetempfac,
     parseelement,
     parsecharge,
-    spacestring
+    spacestring,
+    coordspec,
+    floatspec
 
 
 fmtdir = BioCore.Testing.get_bio_fmt_specimens()
@@ -1246,26 +1249,31 @@ end
     @test_throws ArgumentError spaceatomname(Atom(1, "1MG",   ' ', [0.0, 0.0, 0.0], 1.0, 0.0, "MG", "  ", res))
 
 
+    # Test output formatting
+    @test fmt(coordspec, 5.0) == "5.000"
+    @test fmt(floatspec, -10.0) == "-10.00"
+
+
     # Test pdbline
     ch_a = Chain('A')
     ch_a["1"] = Residue("ALA", 1, ' ', false, ch_a)
     ch_a["1"][" N  "] = Atom(10, " N  ", ' ', [0.0, 0.0, 0.0], 1.0, 0.0, " N", "  ", ch_a["1"])
     line = pdbline(ch_a["1"][" N  "])
-    @test line == "ATOM     10  N   ALA A   1         0.0     0.0     0.0   1.0   0.0           N  "
+    @test line == "ATOM     10  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N  "
     ch_b = Chain('B')
     ch_b["H_20"] = Residue("X", 20, ' ', true, ch_b)
     ch_b["H_20"]["C"] = Atom(101, "C", 'A', [10.5, 20.12345, -5.1227], 0.50, 50.126, "C", "1+", ch_b["H_20"])
     line = pdbline(ch_b["H_20"]["C"])
-    @test line == "HETATM  101  C  A  X B  20        10.5  20.123  -5.123   0.5 50.13           C1+"
+    @test line == "HETATM  101  C  A  X B  20      10.500  20.123  -5.123  0.50 50.13           C1+"
     ch_b["H_20"]["11H11"] = Atom(1, "11H11", ' ', [0.0, 0.0, 0.0], 1.0, 0.0, " H", "  ", ch_b["H_20"])
     @test_throws ArgumentError pdbline(ch_b["H_20"]["11H11"])
 
     line_a = "ATOM    669  CA  ILE A  90      31.743  33.110  31.221  1.00 25.76           C  "
     line_b = "HETATM 3474  O  B XX A 334A      8.802  62.000   8.672  1.00 39.15           O1-"
     at_rec = AtomRecord(line_a)
-    @test pdbline(at_rec) == "ATOM    669  CA  ILE A  90      31.743   33.11  31.221   1.0 25.76           C  "
+    @test pdbline(at_rec) == "ATOM    669  CA  ILE A  90      31.743  33.110  31.221  1.00 25.76           C  "
     at_rec = AtomRecord(line_b)
-    @test pdbline(at_rec) == "HETATM 3474  O  B XX A 334A      8.802    62.0   8.672   1.0 39.15           O1-"
+    @test pdbline(at_rec) == "HETATM 3474  O  B XX A 334A      8.802  62.000   8.672  1.00 39.15           O1-"
 
 
     # Test writepdb

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1540,6 +1540,16 @@ end
         "_atom_site.Cartn_y", "_atom_site.Cartn_z"
     ]
 
+    keyerr_str = """
+        data_test
+        loop_
+        bad.key
+        bad.key2
+        1 2
+        3 4
+        """
+    @test_throws ArgumentError MMCIFDict(IOBuffer(keyerr_str))
+
 
     # Test splitline
     @test splitline("foo bar") == ["foo", "bar"]
@@ -1718,6 +1728,11 @@ end
     @test modelnumber.(mods) == [5, 10]
     @test z(mods[2]['A'][5]["CA"]) == -5.667
     @test countmodels(Model[struc[10], struc[5]]) == 2
+
+
+    # Test files that should not parse
+    @test_throws Exception read(testfilepath("mmCIF", "1AKE_err.cif"), MMCIF)
+    @test_throws ErrorException read(testfilepath("mmCIF", "1EN2_err.cif"), MMCIF)
 
 
     # Test formatting


### PR DESCRIPTION
The standard PDB archive format since 2014 has been mmCIF: https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax

This PR (currently work in progress) adds a reader and writer of the mmCIF format. It reads mmCIF files into the same hierarchical model as PDB files, or you can just access the mmCIF dictionary directly. The same API as for PDB files is maintained for reading and writing.