### PR TITLE
Allow truncated MODEL line in PDB files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/build/
 docs/site/
 .DS_Store
 todo.txt
+.tags*

--- a/src/pdb.jl
+++ b/src/pdb.jl
@@ -490,7 +490,7 @@ function Base.read(input::IO,
         # Read MODEL record
         elseif startswith(line, "MODEL ")
             try
-                curr_model = parse(Int, line[11:14])
+                curr_model = parse(Int, line[11:end])
             catch
                 throw(PDBParseError(
                     "Could not read model serial number", line_n, line))

--- a/src/pdb.jl
+++ b/src/pdb.jl
@@ -490,7 +490,7 @@ function Base.read(input::IO,
         # Read MODEL record
         elseif startswith(line, "MODEL ")
             try
-                curr_model = parse(Int, line[11:end])
+                curr_model = parse(Int, line[11:min(14, end)])
             catch
                 throw(PDBParseError(
                     "Could not read model serial number", line_n, line))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1260,11 +1260,9 @@ end
     @test_throws PDBParseError read(testfilepath("PDB", "1AKE_err_a.pdb"), PDB)
     # Missing chain ID (line ends early)
     @test_throws PDBParseError read(testfilepath("PDB", "1AKE_err_b.pdb"), PDB)    
-    
-    struc = read(testfilepath("PDB", "1SSU_err.pdb"), PDB)
-    @test isa(struc, ProteinStructure)
-    @test countmodels(struc) == 2
-    # TODO replace the above with the below once the pull request to BioFmtSpecimens is merged in
+    # Bad MODEL record
+    @test_throws PDBParseError read(testfilepath("PDB", "1SSU_err.pdb"), PDB)
+    # TODO uncomment this after PR BioFmtSpecimens#28 is merged
     # struc = read(testfilepath("PDB", "d9pcya_.ent"), PDB)
     # @test isa(struc, ProteinStructure)
     # @test countmodels(struc) == 16

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1259,9 +1259,16 @@ end
     # Missing coordinate (blank string)
     @test_throws PDBParseError read(testfilepath("PDB", "1AKE_err_a.pdb"), PDB)
     # Missing chain ID (line ends early)
-    @test_throws PDBParseError read(testfilepath("PDB", "1AKE_err_b.pdb"), PDB)
-    # Bad MODEL record
-    @test_throws PDBParseError read(testfilepath("PDB", "1SSU_err.pdb"), PDB)
+    @test_throws PDBParseError read(testfilepath("PDB", "1AKE_err_b.pdb"), PDB)    
+    
+    struc = read(testfilepath("PDB", "1SSU_err.pdb"), PDB)
+    @test isa(struc, ProteinStructure)
+    @test countmodels(struc) == 2
+    # TODO replace the above with the below once the pull request to BioFmtSpecimens is merged in
+    # struc = read(testfilepath("PDB", "d9pcya_.ent"), PDB)
+    # @test isa(struc, ProteinStructure)
+    # @test countmodels(struc) == 16
+    
     # Duplicate atom names in same residue
     @test_throws ErrorException read(testfilepath("PDB", "1AKE_err_c.pdb"), PDB)
     # Non-existent file

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1262,10 +1262,10 @@ end
     @test_throws PDBParseError read(testfilepath("PDB", "1AKE_err_b.pdb"), PDB)    
     # Bad MODEL record
     @test_throws PDBParseError read(testfilepath("PDB", "1SSU_err.pdb"), PDB)
-    # TODO uncomment this after PR BioFmtSpecimens#28 is merged
-    # struc = read(testfilepath("PDB", "d9pcya_.ent"), PDB)
-    # @test isa(struc, ProteinStructure)
-    # @test countmodels(struc) == 16
+    # Truncated MODEL record from ASTRAL/SCOP95
+    struc = read(testfilepath("PDB", "d9pcya_.ent"), PDB)
+    @test isa(struc, ProteinStructure)
+    @test countmodels(struc) == 16
     
     # Duplicate atom names in same residue
     @test_throws ErrorException read(testfilepath("PDB", "1AKE_err_c.pdb"), PDB)


### PR DESCRIPTION
See https://github.com/BioJulia/BioFmtSpecimens/pull/28
Once that is merged, tests should be updated in this PR. 
`BioFmtSpecimens/PDB/1SSU_err.pdb` is referenced from the tests, but it does not generate an error any longer, so should be replaced with a real file from SCOPe