### PR TITLE
Add get(mmcif, key, default) method for MMCIFDict.

### DIFF
--- a/src/mmcif.jl
+++ b/src/mmcif.jl
@@ -72,6 +72,7 @@ end
 Base.keys(mmcif_dict::MMCIFDict) = keys(mmcif_dict.dict)
 Base.values(mmcif_dict::MMCIFDict) = values(mmcif_dict.dict)
 Base.haskey(mmcif_dict::MMCIFDict, key) = haskey(mmcif_dict.dict, key)
+Base.get(mmcif_dict::MMCIFDict, key, default) = get(mmcif_dict.dict, key, default)
 
 function Base.show(io::IO, mmcif_dict::MMCIFDict)
     print(io, "mmCIF dictionary with $(length(keys(mmcif_dict))) fields")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1594,6 +1594,9 @@ end
     @test length(values(dic)) == 610
     @test haskey(dic, "_cell.entry_id")
     @test !haskey(dic, "nokey")
+    @test get(dic, "_cell.entry_id", ["default"]) == ["1AKE"]
+    @test get(dic, "nokey", ["default"]) == ["default"]
+    @test ismissing(get(dic, "nokey", missing))
     show(devnull, dic)
 
     multiline_str = """


### PR DESCRIPTION
# Add get(mmcif, key, default) method for MMCIFDict

This forwards the get method with a default return value for a MMCIFDict to the underlying Dict.
This can make code a bit more compact by saving the try... catch... and perhaps a bit more efficient by not needing to throw exceptions.
