### PR TITLE
Add MMCIF reading and writing with gzip compression

### DIFF
--- a/docs/src/documentation.md
+++ b/docs/src/documentation.md
@@ -26,6 +26,7 @@ ProteinStructure 1EN2.pdb with 1 models, 1 chains (A), 85 residues, 754 atoms
 ```
 
 mmCIF files can be read into the same data structure with `read("/path/to/cif/file.cif", MMCIF)`.
+The keyword argument `gzip`, default `false`, determines if the file is gzipped.
 If you want to read an mmCIF file into a dictionary to query yourself (e.g. to access metadata fields), use [`MMCIFDict`](@ref):
 
 ```julia
@@ -460,7 +461,7 @@ Various options can be set through optional keyword arguments when parsing PDB/m
 | `remove_disorder::Bool=false`    | Whether to remove atoms with alt loc ID not ' ' or 'A'                       |
 | `read_std_atoms::Bool=true`      | Whether to read standard ATOM records                                        |
 | `read_het_atoms::Bool=true`      | Whether to read HETATOM records                                              |
-| `gzip::Bool=false`               | Whether the file is gzipped (MMTF files only)                                |
+| `gzip::Bool=false`               | Whether the file is gzipped (MMTF and MMCIF files only)                                |
 
 Use [`retrievepdb`](@ref) to download and parse a PDB file into a Structure-Model-Chain-Residue-Atom framework in a single line:
 
@@ -517,6 +518,7 @@ writepdb("1EN2_out.pdb", struc, backboneselector)
 
 To write mmCIF format files, use the [`writemmcif`](@ref) function with similar arguments.
 A [`MMCIFDict`](@ref) can also be written using [`writemmcif`](@ref):
+The `gzip` keyword argument, default `false`, determines whether to gzip the written file.
 
 ```julia
 writemmcif("1EN2_out.dic", mmcif_dict)

--- a/src/mmtf.jl
+++ b/src/mmtf.jl
@@ -4,8 +4,8 @@ export
     writemmtf
 
 """
-    MMTFDict(filepath)
-    MMTFDict(io)
+    MMTFDict(filepath; gzip=false)
+    MMTFDict(io; gzip=false)
     MMTFDict()
 
 A Macromolecular Transmission Format (MMTF) dictionary.
@@ -184,8 +184,8 @@ function generatechainid(entity_id::Integer)
 end
 
 """
-    writemmtf(output, element, atom_selectors...)
-    writemmtf(output, mmtf_dict)
+    writemmtf(output, element, atom_selectors...; gzip=false)
+    writemmtf(output, mmtf_dict; gzip=false)
 
 Write a `StructuralElementOrList` or a `MMTFDict` to a MMTF file or output
 stream.


### PR DESCRIPTION
# Add MMCIF reading and writing with gzip compression 

This adds a gzip keyword in the same manner as the MMTF functions have.

Sorry that the patch for the tests is rather noisy and hard to compare, but that was the easiest way to test many things without adding a lot of extra code.  Let me know if you want it changed in any way.

I also didn't add anything to the downloadpdb... functions.  Not sure what the best way do that would be, perhaps a decompress=true keyword.  I personally don't use those functions at the moment (using the PDB rsync).

I have not checked any influence on performance, hoping that there is none.

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

- If you have implemented new features or behaviour
  - **Provide a description of the addition** in as many details as possible.
See above

  - **Provide justification of the addition**.
Makes it easier to work with gzip-compressed mmcif files, as in the mmtf case.

  - **Provide a runnable example of use of your addition**.

At the shell:
```sh
    $ wget https://files.rcsb.org/download/1AKI.cif.gz
```

In Julia:
```julia
using BioStructures
cif = MMCIFDict("1AKI.cif.gz"; gzip=true)
```

  - **Does your change alter APIs or existing exposed methods/types?**
This adds a new keyword argument to mmcif functions, which (i believe) shouldn't affect existing usage.

## :ballot_box_with_check: Checklist

Note: the julia style guide link and the documentation style guide links don't work.

- [ ] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
