### PR TITLE
Add ProteinStructure constructors from MMCIFDict and MMTFDict 

### DIFF
--- a/docs/src/documentation.md
+++ b/docs/src/documentation.md
@@ -46,6 +46,18 @@ The keyword argument `gzip`, default `false`, determines if the file is gzipped.
 In a similar manner to mmCIF dictionaries, a MMTF file can be read into a dictionary with [`MMTFDict`](@ref).
 The values of the dictionary are a variety of types depending on the [MMTF specification](https://github.com/rcsb/mmtf/blob/master/spec.md).
 
+To convert a [`MMCIFDict`](@ref) or [`MMTFDict`](@ref) to the
+Structure-Model-Chain-Residue-Atom framework, use the
+`ProteinStructure` constructor:
+
+```julia
+julia> struc = ProteinStructure(mmcif_dict)
+ProteinStructure 1EN2.pdb with 1 models, 1 chains (A), 85 residues, 754 atoms
+
+julia> struc = ProteinStructure(mmtf_dict)
+ProteinStructure 1EN2.pdb with 1 models, 1 chains (A), 85 residues, 754 atoms
+```
+
 The elements of `struc` can be accessed as follows:
 
 | Command                     | Returns                                                                         | Return type       |

--- a/src/mmcif.jl
+++ b/src/mmcif.jl
@@ -276,6 +276,18 @@ function Base.read(input::IO,
         tokens = tokenizecifstructure(input)
     end
     populatedict!(mmcif_dict, tokens)
+    ProteinStructure(mmcif_dict;
+                     structure_name=structure_name,
+                     remove_disorder=remove_disorder,
+                     read_std_atoms=read_std_atoms,
+                     read_het_atoms=read_het_atoms)
+end
+
+function ProteinStructure(mmcif_dict::MMCIFDict;
+            structure_name::AbstractString="",
+            remove_disorder::Bool=false,
+            read_std_atoms::Bool=true,
+            read_het_atoms::Bool=true)
     # Define ProteinStructure and add to it incrementally
     struc = ProteinStructure(structure_name)
     if haskey(mmcif_dict, "_atom_site.id")

--- a/src/mmtf.jl
+++ b/src/mmtf.jl
@@ -93,7 +93,19 @@ function Base.read(input::IO,
             read_std_atoms::Bool=true,
             read_het_atoms::Bool=true,
             gzip::Bool=false)
-    d = parsemmtf(input; gzip=gzip)
+    d = MMTFDict(parsemmtf(input; gzip=gzip))
+    ProteinStructure(d;
+                     structure_name=structure_name,
+                     remove_disorder=remove_disorder,
+                     read_std_atoms=read_std_atoms,
+                     read_het_atoms=read_het_atoms)
+end
+
+function ProteinStructure(d::MMTFDict;
+            structure_name::AbstractString="",
+            remove_disorder::Bool=false,
+            read_std_atoms::Bool=true,
+            read_het_atoms::Bool=true)
     struc = ProteinStructure(structure_name)
     # Extract hetero atom information from entity list
     hets = trues(length(d["chainIdList"]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -220,6 +220,10 @@ end
     # Test alternate constructors
     ProteinStructure("struc", Dict(1=> Model()))
     ProteinStructure()
+    mmcif_dict = MMCIFDict(testfilepath("mmCIF", "1AKE.cif"))
+    struc_mmcif_1ake = ProteinStructure(mmcif_dict)
+    mmtf_dict = MMTFDict(testfilepath("MMTF", "1AKE.mmtf"))
+    struc_mmtf_1ake = ProteinStructure(mmtf_dict)
 
     Model(1, Dict("A"=> Chain('A')), ProteinStructure())
     Model(1, ProteinStructure())


### PR DESCRIPTION
# Add ProteinStructure constructors from MMCIFDict and MMTFDict 

This adds two new constructors
```julia
ProteinStructure(::MMCIFDict; kwargs...)
ProteinStructure(::MMTFDict; kwargs...)
```

Having these functions allows one to avoid having to parse a mmCIF or MMTF file twice in the case where one wants both the dictionary and the ProteinStructure with the coordinates.

I imagine there is a small performance benefit as well as reduced disk traffic (which can be slow on a networked file system).

Not sure if adding an additional constructor is the right way to do this, but that way i didn't have to introduce new function names.

## Example

```julia
# Example for the mmCIF case
# before
mmcif_dict = MMCIFDict("path/to/file.cif")
struc = read("path/to/file.cif", MMCIF)

# after:
mmcif_dict = MMCIFDict("path/to/file.cif")
struc = ProteinStructure(mmcif_dict)
```

## Benchmark on 4v4g (a rather extreme example)

```julia
julia> @btime (cif = MMCIFDict("4v4g.cif.gz"; gzip=true); struc = read("4v4g.cif.gz", MMCIF; gzip=true));
  8.893 s (49723548 allocations: 3.70 GiB)

julia> @btime (cif = MMCIFDict("4v4g.cif.gz"; gzip=true); struc = ProteinStructure(cif));
  5.762 s (28749625 allocations: 2.28 GiB)
```
