### PR TITLE
Tab completion in the REPL for MMCIFDict and MMTFDict

### DIFF
--- a/src/mmcif.jl
+++ b/src/mmcif.jl
@@ -55,7 +55,7 @@ Call `MMCIFDict` with a filepath or stream to read the dictionary from that
 source.
 The keyword argument `gzip` (default `false`) determines if the input is gzipped.
 """
-struct MMCIFDict
+struct MMCIFDict <: AbstractDict{String,Vector{String}}
     dict::Dict{String, Vector{String}}
 end
 
@@ -74,9 +74,12 @@ Base.keys(mmcif_dict::MMCIFDict) = keys(mmcif_dict.dict)
 Base.values(mmcif_dict::MMCIFDict) = values(mmcif_dict.dict)
 Base.haskey(mmcif_dict::MMCIFDict, key) = haskey(mmcif_dict.dict, key)
 Base.get(mmcif_dict::MMCIFDict, key, default) = get(mmcif_dict.dict, key, default)
+Base.length(mmcif_dict::MMCIFDict) = length(mmcif_dict.dict)
+Base.iterate(mmcif_dict::MMCIFDict) = iterate(mmcif_dict.dict)
+Base.iterate(mmcif_dict::MMCIFDict, i) = iterate(mmcif_dict.dict, i)
 
 function Base.show(io::IO, mmcif_dict::MMCIFDict)
-    print(io, "mmCIF dictionary with $(length(keys(mmcif_dict))) fields")
+    print(io, "mmCIF dictionary with $(length(mmcif_dict)) fields")
 end
 
 # Split a mmCIF line into tokens

--- a/src/mmtf.jl
+++ b/src/mmtf.jl
@@ -18,7 +18,7 @@ Call `MMTFDict` with a filepath or stream to read the dictionary from that
 source.
 The keyword argument `gzip` (default `false`) determines if the file is gzipped.
 """
-struct MMTFDict
+struct MMTFDict <: AbstractDict{String,Any}
     dict::Dict{String, Any}
 end
 
@@ -82,9 +82,12 @@ Base.keys(mmtf_dict::MMTFDict) = keys(mmtf_dict.dict)
 Base.values(mmtf_dict::MMTFDict) = values(mmtf_dict.dict)
 Base.haskey(mmtf_dict::MMTFDict, key) = haskey(mmtf_dict.dict, key)
 Base.get(mmtf_dict::MMTFDict, key, default) = get(mmtf_dict.dict, key, default)
+Base.length(mmtf_dict::MMTFDict) = length(mmtf_dict.dict)
+Base.iterate(mmtf_dict::MMTFDict) = iterate(mmtf_dict.dict)
+Base.iterate(mmtf_dict::MMTFDict, i) = iterate(mmtf_dict.dict, i)
 
 function Base.show(io::IO, mmtf_dict::MMTFDict)
-    print(io, "MMTF dictionary with $(length(keys(mmtf_dict))) fields")
+    print(io, "MMTF dictionary with $(length(mmtf_dict)) fields")
 end
 
 function Base.read(input::IO,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2226,6 +2226,10 @@ end
     # Test MMTF dictionary
     dic = MMTF()
     dic = MMTFDict(Dict())
+    # Test Base.show
+    show(IOBuffer(), MIME("text/plain"), MMTFDict())
+    show(IOBuffer(), MIME("text/plain"), MMTFDict(Dict("a" => "b")))
+
     dic = MMTFDict(testfilepath("MMTF", "1AKE.mmtf"))
     @test isa(dic.dict, Dict{String, Any})
     @test dic["rWork"] == 0.196f0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1613,6 +1613,10 @@ end
     dic = MMCIFDict()
     dic = MMCIFDict(Dict())
 
+    # Test Base.show
+    show(IOBuffer(), MIME("text/plain"), MMCIFDict())
+    show(IOBuffer(), MIME("text/plain"), MMCIFDict(Dict("a" => ["b"])))
+
     mmcif_1ake = testfilepath("mmCIF", "1AKE.cif")
     gzip_file(mmcif_1ake, temp_filename)
     for dic in (MMCIFDict(mmcif_1ake), MMCIFDict(temp_filename; gzip=true))


### PR DESCRIPTION
# Tab completion for MMCIFDict and MMTFDict in the REPL

This works the same as for a normal `Dict`.

In the REPL, if `mmcif` is a `MMCIFDict`, the following now works: typing `mmcif[` and then the tab key brings up a list of possible keys and will complete a partial key as far as possible. Similarly for `MMTFDict`.

For me this is a nice usability improvement when working in the REPL.

After adding the subtyping to `MMCIFDict` / `MMTFDict`, the tests all passed.  But when working in the REPL, `Base.show` failed. Adding the `Base.length` and `Base.iterate` methods fixed this. I therefore also added a simple test that `Base.show` at least can run.