### PR TITLE
Add readmultimmcif, writemultimmcif functions

### DIFF
--- a/docs/src/documentation.md
+++ b/docs/src/documentation.md
@@ -550,6 +550,21 @@ julia> pdbline(AtomRecord(false, 669, "CA", ' ', "ILE", "A", 90, ' ', [31.743, 3
 
 This can be useful when writing PDB files from your own data structures.
 
+## Reading multiple mmCIF data blocks
+
+You can read and write files containing multiple mmCIF
+data blocks (equivalent to an `MMCIFDict` in this package) with the
+[`readmultimmcif`](@ref) and [`writemultimmcif`](@ref)
+functions.  An example of such a file is the PDB's
+[Chemical component dictionary](https://www.wwpdb.org/data/ccd).
+
+```julia
+julia> ccd = readmultimmcif("components.cif.gz"; gzip=true);
+
+julia> ccd["2W4"]
+mmCIF dictionary with 64 fields
+```
+
 ## RCSB PDB utility functions
 
 To get the list of all PDB entries:

--- a/src/mmcif.jl
+++ b/src/mmcif.jl
@@ -1,6 +1,8 @@
 export
     MMCIFDict,
-    writemmcif
+    readmultimmcif,
+    writemmcif,
+    writemultimmcif
 
 # mmCIF special characters
 const quotechars = Set(['\'', '\"'])
@@ -548,4 +550,76 @@ function appendatom!(atom_dict, at, model_n, chain_id, res_n, res_name, het)
     push!(atom_dict["_atom_site.auth_asym_id"], chain_id)
     push!(atom_dict["_atom_site.auth_atom_id"], atomname(at))
     push!(atom_dict["_atom_site.pdbx_PDB_model_num"], model_n)
+end
+
+"""
+    readmultimmcif(io::IO; gzip=false) -> Dict{String,MMCIFDict}
+    readmultimmcif(filepath::AbstractString; gzip=false) -> Dict{String,MMCIFDict}
+
+Read multiple `MMCIFDict`s from a filepath or stream.  Each `MMCIFDict` in the returned dictionary
+corresponds to an mmCIF data block from the input.
+An example of such a file is the Chemical Component Dictionary from the Protein Data Bank.
+The keyword argument `gzip` (default `false`) determines if the input is gzipped.
+"""
+function readmultimmcif(filepath::AbstractString; gzip::Bool=false)
+    open(filepath) do io
+        readmultimmcif(io; gzip=gzip)
+    end
+end
+
+function readmultimmcif(io::IO; gzip::Bool=false)
+    if gzip
+        gz = GzipDecompressorStream(io)
+        tokens = tokenizecif(gz)
+        close(gz)
+    else
+        tokens = tokenizecif(io)
+    end
+    idx = findall(t -> startswith(t, "data_"), tokens)
+    multicif = Dict{String,MMCIFDict}()
+    push!(idx, length(tokens) + 1)  # add end index for last block
+    for i = 1:length(idx)-1
+        idx_start = idx[i]
+        idx_end = idx[i+1] - 1
+        data_token = tokens[idx_start]
+        cif = MMCIFDict()
+        cif_name = data_token[6:end]
+        if haskey(multicif, cif_name)
+            throw(ErrorException("more than one mmCIF data block for data_$cif_name"))
+        end
+        cif["data_"] = [cif_name]
+        populatedict!(cif, tokens[idx_start+1:idx_end])
+        multicif[cif_name] = cif
+    end
+    return multicif
+end
+
+"""
+    writemultimmcif(io::IO; cifs::Dict{String,MMCIFDict}; gzip=false)
+    writemultimmcif(filepath::AbstractString, cifs::Dict{String,MMCIFDict}; gzip=false)
+
+Write multiple `MMCIFDict`s to a filepath or stream.
+The keyword argument `gzip` (default `false`) determines if the output is gzipped.
+"""
+function writemultimmcif(filepath::AbstractString, cifs::Dict{String,MMCIFDict}; gzip::Bool=false)
+    open(filepath,"w") do f
+        writemultimmcif(f, cifs; gzip=gzip)
+    end
+end
+
+function writemultimmcif(io::IO, cifs::Dict{String,MMCIFDict}; gzip::Bool=false)
+    if gzip
+        io = GzipCompressorStream(io)
+    end
+    for (k,c) in cifs
+        c_key = c["data_"][1]
+        if k != c_key
+            @warn "writemultimmcif: MMCIFDict for key \"$k\" has different \"data_\" key (\"$c_key\")"
+        end
+        writemmcif(io, c)
+        write(io, "##\n\n")
+    end
+    if gzip
+        close(io)
+    end
 end


### PR DESCRIPTION
# Add readmultimmcif, writemultimmcif functions

An mmCIF file can have multiple data_ blocks, thereby containing multiple `MMCIFDict`s. An example of such a file is the Chemical Components Dictionary from the Protein Data Bank. The added functions allow reading and writing such files.

I added new functions in order to not have to change existing functions and the API. The existing parsing infrastructure was used as much as possible.

## Example
Using the [Chemical Components Dictionary](https://www.wwpdb.org/data/ccd) mmCIF file:
```julia
julia> ccd = readmultimmcif("components.cif.gz"; gzip=true)

julia> ccd["2WA"]
mmCIF dictionary with 64 fields

julia> ccd["HNG"]
mmCIF dictionary with 69 fields
```


## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).