### PR TITLE
Fix Kabsch Algorithm to Prevent Reflections

### DIFF
--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -200,6 +200,9 @@ function Transformation(coords1::Array{<:Real, 2},
     # Find the rotation that maps the coordinates
     cov = p * transpose(q)
     svd_res = svd(cov)
+    # Check sign of determinant
+    d = sign(det(svd_res.U)*det(svd_res.V))
+    @view(svd_res.V[:,end]) .*= d
     rot = svd_res.V * transpose(svd_res.U)
     return Transformation(trans1, trans2, rot, inds1, inds2)
 end

--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -201,7 +201,7 @@ function Transformation(coords1::Array{<:Real, 2},
     cov = p * transpose(q)
     svd_res = svd(cov)
     # Check sign of determinant
-    d = sign(det(svd_res.U)*det(svd_res.V))
+    d = sign(det(svd_res.V * transpose(svd_res.U)))
     @view(svd_res.V[:,end]) .*= d
     rot = svd_res.V * transpose(svd_res.U)
     return Transformation(trans1, trans2, rot, inds1, inds2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using CodecZlib
 using DataFrames
 using Format
 using Graphs
+using LinearAlgebra
 using MetaGraphs
 using RecipesBase
 
@@ -2829,6 +2830,22 @@ end
         0.0  0.0 1.0
     ]
     @test isapprox(trans.rot, rot_real)
+
+    # Test rot isn't a reflection
+    cs_one = Float64[
+        1 -1  0  0  0  0
+        0  0  1 -1  0  0
+        0  0  0  0  1 -1
+    ]
+    cs_two = Float64[
+        -1  1  0  0  0  0
+         0  0  1 -1  0  0
+         0  0  0  0  1 -1
+    ]
+    trans = Transformation(cs_one, cs_two)
+    @test isapprox(trans.trans1, [0.0, 0.0, 0.0])
+    @test isapprox(trans.trans2, [0.0, 0.0, 0.0])
+    @test isapprox(det(trans.rot), 1.0)
 
     cs_one = [
          7.0  5.0  3.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2834,18 +2834,24 @@ end
     # Test rot isn't a reflection
     cs_one = Float64[
         1 -1  0  0  0  0
-        0  0  1 -1  0  0
-        0  0  0  0  1 -1
+        0  0  2 -2  0  0
+        0  0  0  0  2 -2
     ]
     cs_two = Float64[
         -1  1  0  0  0  0
-         0  0  1 -1  0  0
-         0  0  0  0  1 -1
+         0  0  2 -2  0  0
+         0  0  0  0  2 -2
     ]
     trans = Transformation(cs_one, cs_two)
     @test isapprox(trans.trans1, [0.0, 0.0, 0.0])
     @test isapprox(trans.trans2, [0.0, 0.0, 0.0])
     @test isapprox(det(trans.rot), 1.0)
+    rot_real = [
+        1.0 0.0 0.0
+        0.0 1.0 0.0
+        0.0 0.0 1.0
+    ]
+    @test isapprox(trans.rot, rot_real)
 
     cs_one = [
          7.0  5.0  3.0


### PR DESCRIPTION
# Fix Kabsch Algorithm to Prevent Reflections

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [x] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

Before this change, the `rot` field of `Transformation` could be a reflection instead of a pure rotation.

This change ensures that `rot` will be a pure rotation, with determinant 1.

See https://en.wikipedia.org/wiki/Kabsch_algorithm#Computation_of_the_optimal_rotation_matrix
