### PR TITLE
fix compat note

### DIFF
--- a/docs/src/documentation.md
+++ b/docs/src/documentation.md
@@ -274,7 +274,7 @@ In fact, [`pairalign`](@ref) is extended to carry out the above steps and return
 ## String selection syntax
 
 !!! compat
-    The string-selection syntax was introduced in version 3.13.
+    The string-selection syntax was introduced in version 3.2.0
 
 `BioStructures.jl` exports the `sel` macro that provides a practical way to collect atoms from a structure
 using a natural selection syntax. It must be used as: 


### PR DESCRIPTION
Noticed that I saw wrongly the current version. Updated the compat note for the selection syntax for the next feature-release.