### PR TITLE
Add recursive copy for structures

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -338,6 +338,15 @@ end
 Base.firstindex(struc::MolecularStructure) = first(modelnumbers(struc))
 Base.lastindex(struc::MolecularStructure) = last(modelnumbers(struc))
 
+# recursive copy methods
+Base.copy(a::Atom) = Atom(a.serial, a.name, a.alt_loc_id, copy(coords(a)), a.occupancy, a.temp_factor, a.element, a.charge, a.residue)
+Base.copy(da::DisorderedAtom) = DisorderedAtom(copy(da.alt_loc_ids), da.default)
+Base.copy(r::Residue) = Residue(r.name, r.number, r.ins_code, r.het_res, [name for name in r.atom_list], Dict(k => copy(a) for (k, a) in r.atoms), r.chain, r.ss_code)
+Base.copy(dr::DisorderedResidue) = DisorderedResidue(Dict(k => copy(r) for (k, r) in dr.names), dr.default)
+Base.copy(c::Chain) = Chain(c.id, [id for id in c.res_list], Dict(k => copy(r) for (k, r) in c.residues), c.model)
+Base.copy(m::Model) = Model(m.number, Dict(k => copy(c) for (k, c) in m.chains), m.structure)
+Base.copy(s::MolecularStructure) = MolecularStructure(s.name, Dict(k => copy(m) for (k, m) in s.models))
+
 # Check if an atom name exists in a residue as a whitespace-padded version
 function findatombyname(res::Residue, atom_name::AbstractString)
     # Look for atom name directly

--- a/src/model.jl
+++ b/src/model.jl
@@ -375,9 +375,9 @@ Base.lastindex(struc::MolecularStructure) = last(modelnumbers(struc))
 
 # recursive copy methods. If we copy a subelement (anything below MolecularStructure), it shares the parent element
 Base.copy(a::Atom) = Atom(a, a.residue)
-Base.copy(da::DisorderedAtom) = DisorderedAtom(da, only(unique(values(da.alt_loc_ids))))
+Base.copy(da::DisorderedAtom) = DisorderedAtom(da, only(unique(a -> a.residue, values(da.alt_loc_ids))).residue)
 Base.copy(r::Residue) = Residue(r, r.chain)
-Base.copy(dr::DisorderedResidue) = DisorderedResidue(dr, only(unique(values(dr.names))))
+Base.copy(dr::DisorderedResidue) = DisorderedResidue(dr, only(unique(r -> r.chain, values(dr.names))).chain)
 Base.copy(c::Chain) = Chain(c, c.model)
 Base.copy(m::Model) = Model(m, m.structure)
 Base.copy(s::MolecularStructure) = MolecularStructure(s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -259,6 +259,8 @@ end
     testparent(getchildren(res), res)
     res_copy = copy(res)
     testparent(getchildren(res_copy), res_copy)
+    @test copy(dis_res) isa DisorderedResidue
+    @test copy(dis_at) isa DisorderedAtom
 
     # Test alternate constructors
     MolecularStructure("struc", Dict(1 => Model()))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,33 @@ function countlines_gzip(filename::AbstractString; gzip=false)
     end
 end
 
+getparent(a::Atom) = a.residue
+getparent(r::Residue) = r.chain
+getparent(c::Chain) = c.model
+getparent(m::Model) = m.structure
+getchildren(::Atom) = ()
+getchildren(r::Residue) = values(r.atoms)
+getchildren(c::Chain) = values(c.residues)
+getchildren(m::Model) = values(m.chains)
+getchildren(s::MolecularStructure) = values(s.models)
+function testparent(children, parent)
+    for child in children
+        if isa(child, DisorderedAtom)
+            for a in values(child.alt_loc_ids)
+                @test getparent(a) === parent
+            end
+        elseif isa(child, DisorderedResidue)
+            for r in values(child.names)
+                @test getparent(r) === parent
+                testparent(getchildren(r), r)
+            end
+        else
+            @test getparent(child) === parent
+            testparent(getchildren(child), child)
+        end
+    end
+end
+
 Aqua.test_all(BioStructures; ambiguities=(recursive=false))
 
 # This is the only test set that requires an internet connection
@@ -215,11 +242,23 @@ end
     fixlists!(struc)
 
     # copy doesn't share memory
+    testparent(getchildren(struc), struc)
     struc_copy = copy(struc)
+    testparent(getchildren(struc_copy), struc_copy)
     struc_copy['A'][10]["CA"].coords[2] = 100
     @test struc_copy['A'][10]["CA"].coords[2] == 100
     @test a.coords[2] == 2
     @test struc['A'][10]["CA"].coords[2] == 2
+    # intermediate copies preserve parenting up to the node of the copy
+    testparent(getchildren(mo), mo)
+    mo_copy = copy(mo)
+    testparent(getchildren(mo_copy), mo_copy)
+    testparent(getchildren(ch), ch)
+    ch_copy = copy(ch)
+    testparent(getchildren(ch_copy), ch_copy)
+    testparent(getchildren(res), res)
+    res_copy = copy(res)
+    testparent(getchildren(res_copy), res_copy)
 
     # Test alternate constructors
     MolecularStructure("struc", Dict(1 => Model()))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,8 +198,8 @@ end
     ), " VA")
     dis_res = struc['A']["H_20A"]
     @test isa(dis_res, DisorderedResidue)
-    struc['A'][10][" CA "] = Atom(
-        100, " CA ", ' ', [1.0, 2.0, 3.0], 1.0, 10.0, " C", "  ", res)
+    a = Atom(100, " CA ", ' ', [1.0, 2.0, 3.0], 1.0, 10.0, " C", "  ", res)
+    struc['A'][10][" CA "] = a
     at = struc['A'][10]["CA"]
     @test isa(at, Atom)
     struc['A'][10][" CB "] = DisorderedAtom(Dict(
@@ -213,6 +213,13 @@ end
     disorderedres(dis_res, "ILE")[" O  "] = Atom(
         400, " O  ", ' ', [1.0, 2.0, 3.0], 1.0, 10.0, " O", "  ", disorderedres(dis_res, "ILE"))
     fixlists!(struc)
+
+    # copy doesn't share memory
+    struc_copy = copy(struc)
+    struc_copy['A'][10]["CA"].coords[2] = 100
+    @test struc_copy['A'][10]["CA"].coords[2] == 100
+    @test a.coords[2] == 2
+    @test struc['A'][10]["CA"].coords[2] == 2
 
     # Test alternate constructors
     MolecularStructure("struc", Dict(1 => Model()))


### PR DESCRIPTION
Certain methods, like `applytransform!`, exist only in mutating form.
Rather than adding a non-mutating version for every potential mutating
function, we can simply copy the structure, apply the transformation,
and return the new structure.

It's worth thinking about whether we like a recursive `copy`. For things like arrays, `copy` is non-recursive: it copies the outer container but any inner containers are referenced identically. There is, of course, `deepcopy`, but that's glacially slow and very unfriendly to the upcoming (Julia 1.12+) static compilation. It seems like we need some form of fast recursive copy, but whether this is called `Base.copy` or `recursivecopy` is a debatable point. Here I went with the former but will be happy to change it to something else.

But for a tree structure (which is what these are), copying only the root node seems silly. So I think this could easily be `Base.copy`.