### PR TITLE
parse query on Select object creation

### DIFF
--- a/src/select.jl
+++ b/src/select.jl
@@ -436,11 +436,16 @@ allselector(el) = true
 
 # Acts as a function when used within typical julia filtering functions 
 #   by converting a string selection into a query call
-struct Select <: Function
-    sel::String
+struct Select{Q} <: Function
+    query_string::String
+    query::Q
 end
-
-(s::Select)(at) = apply_query(parse_query(s.sel), at)
+function Select(query_string::AbstractString) 
+    query = parse_query(query_string)
+    return Select(query_string, query)
+end
+(s::Select)(at) = apply_query(s.query, at)
+Base.show(io::IO, ::MIME"text/plain", s::Select) = print(io, """Select("$(s.query_string)")""")
 
 "String selection syntax."
 macro sel_str(str)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -940,6 +940,12 @@ end
     @test_throws ArgumentError collectatoms(struc, sel"abc") # Invalid selection syntax
     @test_throws ArgumentError collectatoms(struc, sel"index = A") # Invalid value type
     @test_throws ArgumentError collectatoms(struc, sel"resnum C")
+
+    # test show method for @sel_str
+    sel = Select("name CA and residue 1")
+    buff = IOBuffer()
+    show(buff, MIME"text/plain"(), sel"name CA and residue 1")
+    @test String(take!(buff)) == """Select("name CA and residue 1")"""
 end
 
 @testset "PDB reading" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -937,15 +937,15 @@ end
     @test length(collectmodels(struc, sel"model 1")) == 1
     @test length(collectmodels(struc, sel"model 2")) == 0
 
-    @test_throws ArgumentError collectatoms(struc, sel"abc") # Invalid selection syntax
-    @test_throws ArgumentError collectatoms(struc, sel"index = A") # Invalid value type
-    @test_throws ArgumentError collectatoms(struc, sel"resnum C")
+    @test_throws ArgumentError collectatoms(struc, BioStructures.Select("abc")) # Invalid selection syntax
+    @test_throws ArgumentError collectatoms(struc, BioStructures.Select("index = A")) # Invalid value type
+    @test_throws ArgumentError collectatoms(struc, BioStructures.Select("resnum C"))
 
     # test show method for @sel_str
-    sel = Select("name CA and residue 1")
+    sel = BioStructures.Select("name CA and resnum 1")
     buff = IOBuffer()
-    show(buff, MIME"text/plain"(), sel"name CA and residue 1")
-    @test String(take!(buff)) == """Select("name CA and residue 1")"""
+    show(buff, MIME"text/plain"(), sel"name CA and resnum 1")
+    @test String(take!(buff)) == """Select("name CA and resnum 1")"""
 end
 
 @testset "PDB reading" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -942,7 +942,6 @@ end
     @test_throws ArgumentError collectatoms(struc, BioStructures.Select("resnum C"))
 
     # test show method for @sel_str
-    sel = BioStructures.Select("name CA and resnum 1")
     buff = IOBuffer()
     show(buff, MIME"text/plain"(), sel"name CA and resnum 1")
     @test String(take!(buff)) == """Select("name CA and resnum 1")"""


### PR DESCRIPTION
This PR makes the use of the selection string `@sel_str` much faster, because the query is parsed on the construction of the object, and not on the application of the query to each atom. For example:

Before:

```julia-repl
julia> struc = retrievepdb("4YC6")

julia> @btime collectatoms($struc, $(sel"name CA"));
  37.468 ms (605588 allocations: 16.10 MiB)
```

After:

```julia-repl
julia> @btime collectatoms($struc, $(sel"name CA"));
  889.474 μs (41122 allocations: 2.06 MiB)
```

Also, the `Select` object has a custom show method:

```julia-repl
julia> sel"name CA and resnum 1"
Select("name CA and resnum 1")
```