### PR TITLE
support interpolation in sel"" macro.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -928,6 +928,11 @@ end
     @test length(collectatoms(struc, sel"disordered")) == 68
     @test length(collectatoms(struc, sel"sscode E")) == 2448
     @test length(collectatoms(struc, sel"helix")) == 4047
+    # check interpolation support
+    ss_type = "helix"
+    @test length(collectatoms(struc, sel"$ss_type")) == 4047
+    sel_chains = ('A', 'B')
+    @test length(collectresidues(struc, sel"chain $(first(sel_chains)) or chain $(last(sel_chains))")) == 544
 
     @test length(collectresidues(struc, sel"chain A or chain B")) == 544
     @test length(collectresidues(struc, sel"standard")) == 1420


### PR DESCRIPTION

With this modification, the `sel""` raw-string macro supports interpolated variables. That is, previously, this didn't work:

```julia
atom_name = "CA"
collectatoms(struc, sel"name $atom_name")
```

now it does.