### PR TITLE
Fix computing `Transformation` based on pairwise alignment

### DIFF
--- a/ext/BioStructuresBioAlignmentsExt.jl
+++ b/ext/BioStructuresBioAlignmentsExt.jl
@@ -66,7 +66,9 @@ function BioStructures.Transformation(el1::StructuralElementOrList,
     for (i1, i2) in zip(inds1, inds2)
         sel_ats1 = collectatoms(res1[i1], alignatoms)
         sel_ats2 = collectatoms(res2[i2], alignatoms)
-        if length(atoms1) == length(atoms2)
+        # Ensure `atoms1` and `atoms2` have the same length, ignore residues
+        # where the number of atoms differ.
+        if length(sel_ats1) == length(sel_ats2)
             append!(atoms1, sel_ats1)
             append!(atoms2, sel_ats2)
         end


### PR DESCRIPTION
Thanks for maintaining this package, saves me a lot of work!

I have found a subtle bug in the function that computes a `Transformation` based on a pairwise alignment. In it, we want to collect all atoms belonging to residues that were (mis)matched in the alignment. To ensure that the number of atoms that are later used for the Kabsch algorithm are equal, we have to check for every residue if their atom counts match, even if the residues produced a mismatch in the alignment. However, the previous code only checked if the so-far collected atoms have the same amount (the invariant we want to maintain) where it _should_ check if the atoms about to be added have the same amount.

I adapted the code and added a short explanatory comment. Let me know if anything else should be added!