### PR TITLE
Parse secondary structure annotations from mmCIF

### DIFF
--- a/docs/src/documentation.md
+++ b/docs/src/documentation.md
@@ -286,7 +286,7 @@ The operators currently supported are:
 | Operators                   | Acts on                             |
 | :-------------------------- | :---------------------------------- |
 | `=`, `>`, `<` `>=`, `<=`    | Properties with real values.        |
-| `and`, `or`, `not`          | Selections subsets.                 | 
+| `and`, `or`, `not`          | Selections subsets.                 |
 
 The keywords supported are:
 
@@ -541,13 +541,31 @@ So if you wanted the graph of chain contacts in a protein complex you could give
 
 ## Assigning secondary structure
 
-The secondary structure code of a residue or atom can be accessed after assigning the secondary structure using [DSSP](https://github.com/PDB-REDO/dssp) or [STRIDE](https://webclu.bio.wzw.tum.de/stride).
+Any secondary structure assignment at a residue is accessed via [`sscode`](@ref):
+```julia
+sscode(res)
+sscode(at)
+```
+Or for the whole structure:
+```julia
+sscode.(collectresidues(struc))
+```
+`sscode` may return `'-'`, indicating either that the residue has no recognized secondary structure or that it has not yet been assigned.
+The secondary structure code of a residue can be changed using [`sscode!`](@ref).
+
+mmCIF files with secondary structure [annotations](https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_struct_conf_type.id.html) will, by default, parse and assign secondary structure.
+
+Secondary structure can also be assigned using [DSSP](https://github.com/PDB-REDO/dssp) or [STRIDE](https://webclu.bio.wzw.tum.de/stride).
+This functionality is provided through extensions, so you must load the corresponding package library (`DSSP_jll` or `STRIDE_jll`) before this functionality will work.
+
 To assign secondary structure when reading the structure:
 ```julia
 # Assign secondary structure using DSSP
+using DSSP_jll
 read("/path/to/pdb/file.pdb", PDBFormat, run_dssp=true)
 
 # Assign secondary structure using STRIDE
+using STRIDE_jll
 read("/path/to/pdb/file.pdb", PDBFormat, run_stride=true)
 ```
 [`rundssp!`](@ref), [`runstride!`](@ref), [`rundssp`](@ref) and [`runstride`](@ref) can also be used to assign secondary structure to a [`MolecularStructure`](@ref) or [`Model`](@ref):
@@ -557,21 +575,12 @@ runstride!(struc)
 ```
 The assignment process may fail if the structure is too large, since we use an intermediate PDB file where the atom serial cannot exceed 99999 and the chain ID must be a single character.
 To get access to the secondary structure code of a residue or atom as a `Char`:
-```julia
-sscode(res)
-sscode(at)
-```
-Or for the whole structure:
-```julia
-sscode.(collectresidues(struc))
-```
-The secondary structure code of a residue can be changed using [`sscode!`](@ref).
 [`rundssp`](@ref) and [`runstride`](@ref) can also be run directly on structure files:
 ```julia
 rundssp("/path/to/pdb/file.pdb", "out.dssp") # Also works with mmCIF files
 runstride("/path/to/pdb/file.pdb", "out.stride")
 ```
-See the documentation for [DSSP_jll](https://docs.juliahub.com/General/DSSP_jll/stable/autodocs) and [STRIDE_jll](https://docs.juliahub.com/General/STRIDE_jll/stable/autodocs), and also [ProteinSecondaryStructures.jl](https://github.com/m3g/ProteinSecondaryStructures.jl), for other ways to run these programs.
+See the documentation for [DSSP_jll](https://docs.juliahub.com/General/DSSP_jll/stable/autodocs) and [STRIDE_jll](https://docs.juliahub.com/General/STRIDE_jll/stable/autodocs), and also [ProteinSecondaryStructures.jl](https://github.com/BioJulia/ProteinSecondaryStructures.jl), for other ways to run these programs.
 
 ## Downloading PDB files
 

--- a/src/mmcif.jl
+++ b/src/mmcif.jl
@@ -349,8 +349,13 @@ function MolecularStructure(mmcif_dict::MMCIFDict;
     # Secondary structure assignment
     if !(run_dssp | run_stride) && haskey(mmcif_dict, "_struct_conf.conf_type_id")
         for (i, id) in pairs(mmcif_dict["_struct_conf.conf_type_id"])
-            chainid = mmcif_dict["_struct_conf.beg_label_asym_id"][i]
-            mmcif_dict["_struct_conf.end_label_asym_id"][i] == chainid || continue   # mismatch in chain id
+            chainid = get(mmcif_dict, "_struct_conf.beg_auth_asym_id", nothing)[i]
+            chainidend = get(mmcif_dict, "_struct_conf.end_auth_asym_id", nothing)[i]
+            if chainid === nothing
+                chainid = mmcif_dict["_struct_conf.beg_label_asym_id"][i]
+                chainidend = mmcif_dict["_struct_conf.end_label_asym_id"][i]
+            end
+            chainidend == chainid || continue   # mismatch in chain id
             haskey(chains(struc), chainid) || continue
             chain = struc[chainid]
             bg = tryparse(Int, mmcif_dict["_struct_conf.beg_auth_seq_id"][i])

--- a/src/mmcif.jl
+++ b/src/mmcif.jl
@@ -347,8 +347,7 @@ function MolecularStructure(mmcif_dict::MMCIFDict;
     end
 
     # Secondary structure assignment
-    if haskey(mmcif_dict, "_struct_conf.conf_type_id")
-        (run_dssp | run_stride) && @warn "Secondary structure assignment will be overwritten"
+    if !(run_dssp | run_stride) && haskey(mmcif_dict, "_struct_conf.conf_type_id")
         for (i, id) in pairs(mmcif_dict["_struct_conf.conf_type_id"])
             chainid = mmcif_dict["_struct_conf.beg_label_asym_id"][i]
             mmcif_dict["_struct_conf.end_label_asym_id"][i] == chainid || continue   # mismatch in chain id

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -896,7 +896,7 @@ end
 end
 
 @testset "Selection syntax" begin
-    struc = retrievepdb("4YC6", dir=temp_dir, run_dssp=true)
+    struc = @test_logs (:info, "Downloading file from PDB: 4YC6") (:warn,"Secondary structure assignment will be overwritten") retrievepdb("4YC6", dir=temp_dir, run_dssp=true)
     @test length(collectatoms(struc, sel"all")) == 12271
     @test length(collectatoms(struc, sel"name CA")) == 1420
     @test length(collectatoms(struc, sel"name CA", sel"x > 0")) == 312
@@ -1787,6 +1787,7 @@ end
         @test dic["_pdbx_database_status.recvd_initial_deposition_date"] == ["1991-11-08"]
         @test dic["_audit_author.name"] == ["Mueller, C.W.", "Schulz, G.E."]
         @test length(dic["_atom_site.group_PDB"]) == 3816
+        @test length(dic["_struct_conf.conf_type_id"]) == 18
         dic["_pdbx_database_status.recvd_initial_deposition_date"] = ["changed"]
         @test dic["_pdbx_database_status.recvd_initial_deposition_date"] == ["changed"]
         @test length(keys(dic)) == 610
@@ -1942,10 +1943,14 @@ end
 
     open(testfilepath("mmCIF", "1AKE.cif")) do f
         tokens = tokenizecifstructure(f)
-        @test length(tokens) == 80158
-        @test tokens[1] == "loop_"
-        @test tokens[10] == "_atom_site.label_seq_id"
-        @test tokens[80089] == "77.69"
+        loopidxs = findall(==("loop_"), tokens)
+        @test length(loopidxs) == 2
+        idxsc = loopidxs[1]
+        @test tokens[idxsc + 1] == "_struct_conf.conf_type_id"
+        idxas = loopidxs[2]
+        @test length(tokens) - idxas + 1 == 80158
+        @test tokens[idxas + 9] == "_atom_site.label_seq_id"
+        @test tokens[idxas + 80088] == "77.69"
     end
 
     # Test parsing empty file
@@ -1996,6 +2001,8 @@ end
     res = collect(chs[1])
     @test length(res) == 456
     @test resid(res[20]) == "20"
+    @test sscode(res[11]) == '-'
+    @test sscode(res[12]) == 'H'
     ats = collect(res[20])
     @test length(ats) == 8
     @test atomname.(ats) == ["N", "CA", "C", "O", "CB", "CG1", "CG2", "CD1"]
@@ -3352,7 +3359,7 @@ end
     struc2 = read(pdb_path, PDBFormat; run_dssp=true)
     @test sscode.(collectatoms(struc)) == sscode.(collectatoms(struc2))
 
-    struc3 = read(cif_path, MMCIFFormat; run_dssp=true)
+    struc3 = @test_logs (:warn,"Secondary structure assignment will be overwritten") read(cif_path, MMCIFFormat; run_dssp=true)
     @test sscode.(collectatoms(struc)) == sscode.(collectatoms(struc3))
 
     struc = read(pdb_path, PDBFormat)
@@ -3381,7 +3388,7 @@ end
     struc2 = read(pdb_path, PDBFormat; run_stride=true)
     @test sscode.(collectatoms(struc)) == sscode.(collectatoms(struc2))
 
-    struc3 = read(cif_path, MMCIFFormat; run_stride=true)
+    struc3 = @test_logs (:warn,"Secondary structure assignment will be overwritten") read(cif_path, MMCIFFormat; run_stride=true)
     @test sscode.(collectatoms(struc)) == sscode.(collectatoms(struc3))
 
     isfile(temp_filename) && rm(temp_filename)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -896,7 +896,7 @@ end
 end
 
 @testset "Selection syntax" begin
-    struc = @test_logs (:info, "Downloading file from PDB: 4YC6") (:warn,"Secondary structure assignment will be overwritten") retrievepdb("4YC6", dir=temp_dir, run_dssp=true)
+    struc = retrievepdb("4YC6", dir=temp_dir, run_dssp=true)
     @test length(collectatoms(struc, sel"all")) == 12271
     @test length(collectatoms(struc, sel"name CA")) == 1420
     @test length(collectatoms(struc, sel"name CA", sel"x > 0")) == 312
@@ -3359,7 +3359,7 @@ end
     struc2 = read(pdb_path, PDBFormat; run_dssp=true)
     @test sscode.(collectatoms(struc)) == sscode.(collectatoms(struc2))
 
-    struc3 = @test_logs (:warn,"Secondary structure assignment will be overwritten") read(cif_path, MMCIFFormat; run_dssp=true)
+    struc3 = read(cif_path, MMCIFFormat; run_dssp=true)
     @test sscode.(collectatoms(struc)) == sscode.(collectatoms(struc3))
 
     struc = read(pdb_path, PDBFormat)
@@ -3388,7 +3388,7 @@ end
     struc2 = read(pdb_path, PDBFormat; run_stride=true)
     @test sscode.(collectatoms(struc)) == sscode.(collectatoms(struc2))
 
-    struc3 = @test_logs (:warn,"Secondary structure assignment will be overwritten") read(cif_path, MMCIFFormat; run_stride=true)
+    struc3 = read(cif_path, MMCIFFormat; run_stride=true)
     @test sscode.(collectatoms(struc)) == sscode.(collectatoms(struc3))
 
     isfile(temp_filename) && rm(temp_filename)


### PR DESCRIPTION
While we can get this info from running DSSP, it seems reasonable to extract this information from the file when it is present.

One issue is that the [annotations used](https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Items/_struct_conf_type.id.html) are more detailed than the [one-letter codes](https://pdb-redo.eu/dssp/about). I may not have handled this correctly, and perhaps it may be worth considering if we want to consider an alternative approach. (E.g., an `@enum`?) It might also be nice to include the numeric code, e.g., for TM6. (Presumably there will always be a switch in categorization before the next structure of the same type, so this is not as critical.)