### PR TITLE
Add `chiangles`

### DIFF
--- a/docs/src/documentation.md
+++ b/docs/src/documentation.md
@@ -411,9 +411,11 @@ Various functions are provided to calculate spatial quantities for proteins:
 | [`omegaangle`](@ref)         | Omega dihedral angle between a residue and the previous residue                                  |
 | [`phiangle`](@ref)           | Phi dihedral angle between a residue and the previous residue                                    |
 | [`psiangle`](@ref)           | Psi dihedral angle between a residue and the next residue                                        |
+| [`chiangle`](@ref)           | Chi dihedral angle within a residue                                                              |
 | [`omegaangles`](@ref)        | `Vector` of omega dihedral angles of an element                                                  |
 | [`phiangles`](@ref)          | `Vector` of phi dihedral angles of an element                                                    |
 | [`psiangles`](@ref)          | `Vector` of psi dihedral angles of an element                                                    |
+| [`chiangles`](@ref)          | All chi dihedral angles for a residue or element                                                 |
 | [`ramachandranangles`](@ref) | `Vector`s of phi and psi angles of an element                                                    |
 | [`ContactMap`](@ref)         | `ContactMap` of two elements, or one element with itself                                         |
 | [`DistanceMap`](@ref)        | `DistanceMap` of two elements, or one element with itself                                        |
@@ -446,6 +448,17 @@ julia> rad2deg(psiangle(struc['A'][50], struc['A'][51]))
 
 julia> rad2deg(psiangle(struc['A'], 50))
 -177.38288114072924
+
+julia> rad2deg.(chiangles(struc['A'][2]))    # ASP, χ₁...χ₅
+5-element Vector{Float64}:
+  -55.5708140556466
+ -118.03264320054458
+   56.50403552503829
+ -176.37208357380604
+    0.04991054795811607
+
+julia> rad2deg.(chiangles(struc['A'][4]))    # GLY, no χ angles
+Float64[]
 ```
 
 [`ContactMap`](@ref) takes in a structural element or a list, such as a `Chain` or `Vector{Atom}`, and returns a [`ContactMap`](@ref) object showing the contacts between the elements for a specified distance.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3184,6 +3184,27 @@ end
     @test isapprox(phis[10], phiangle(struc_1AKE['A'], 10), atol=1e-5)
     @test isapprox(omegas[10], omegaangle(struc_1AKE['A'], 10), atol=1e-5)
 
+    # Test that the entries in `chitables` are bonded
+    sortt((a, b)) = a < b ? (a, b) : (b, a)
+    rd = BioStructures.residuedata
+    for ct in BioStructures.chitables
+        for (rname, alist) in ct
+            if rname == "HIS"
+                rname = "HID"
+            end
+            sb = sortt.(rd[rname].bonds)
+            for i = 1:3
+                @test sortt((alist[i], alist[i+1])) ∈ sb
+            end
+        end
+    end
+    chis = chiangles(struc_1AKE['A'], standardselector)
+    @test length(chis) == countresidues(struc_1AKE['A'], standardselector)
+    @test chis[1] ≈ deg2rad.([-176.231, 172.056, 56.069]) rtol=1e-5   # MET
+    @test chis[2] ≈ deg2rad.([-76.551, 171.696, 171.162, -175.969, 0.424]) rtol=1e-5   # ARG
+    @test isempty(chis[7])       # GLY
+    @test chiangle(struc_1AKE['A'][2], 3) == chis[2][3]
+
     # Test ContactMap
     cas = collectatoms(struc_1AKE, calphaselector)[1:10]
     @test isa(ContactMap(cas, 10).data, BitArray{2})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3204,6 +3204,11 @@ end
     @test chis[2] ≈ deg2rad.([-76.551, 171.696, 171.162, -175.969, 0.424]) rtol=1e-5   # ARG
     @test isempty(chis[7])       # GLY
     @test chiangle(struc_1AKE['A'][2], 3) == chis[2][3]
+    @test_throws "GLY does not have any χ angles" chiangle(struc_1AKE['A'][7], 1)
+    @test_throws "χ angle with index 4 does not exist for residue MET (max is 3)" chiangle(struc_1AKE['A'][1], 4)
+    fakeres = Residue("UKN", 10, ' ', false, struc_1AKE['A'])
+    @test_throws "no χ angles are defined for residues with name UKN" chiangle(fakeres, 1)
+    @test_throws "no χ angles are defined for residues with name UKN" chiangles(fakeres)
     # Test symmetries: two ASPs with OD1 and OD2 swapped
     io = IOBuffer("""
         ATOM    534  N   ASP A   1      -8.068   7.150  -2.008  1.00 95.46           N

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3204,6 +3204,33 @@ end
     @test chis[2] ≈ deg2rad.([-76.551, 171.696, 171.162, -175.969, 0.424]) rtol=1e-5   # ARG
     @test isempty(chis[7])       # GLY
     @test chiangle(struc_1AKE['A'][2], 3) == chis[2][3]
+    # Test symmetries: two ASPs with OD1 and OD2 swapped
+    io = IOBuffer("""
+        ATOM    534  N   ASP A   1      -8.068   7.150  -2.008  1.00 95.46           N
+        ATOM    535  CA  ASP A   1      -8.464   6.572  -3.297  1.00 95.46           C
+        ATOM    536  C   ASP A   1      -8.522   7.636  -4.409  1.00 95.46           C
+        ATOM    537  CB  ASP A   1      -9.844   5.896  -3.142  1.00 95.46           C
+        ATOM    538  O   ASP A   1      -8.015   7.431  -5.518  1.00 95.46           O
+        ATOM    539  CG  ASP A   1      -9.818   4.542  -2.418  1.00 95.46           C
+        ATOM    540  OD1 ASP A   1      -8.738   3.930  -2.377  1.00 95.46           O
+        ATOM    541  OD2 ASP A   1     -10.899   4.073  -1.981  1.00 95.46           O
+        """)
+    r = only(only(only(read(io, PDBFormat))))
+    χs1 = chiangles(r)
+    io = IOBuffer("""
+        ATOM    534  N   ASP A   1      -8.068   7.150  -2.008  1.00 95.46           N
+        ATOM    535  CA  ASP A   1      -8.464   6.572  -3.297  1.00 95.46           C
+        ATOM    536  C   ASP A   1      -8.522   7.636  -4.409  1.00 95.46           C
+        ATOM    537  CB  ASP A   1      -9.844   5.896  -3.142  1.00 95.46           C
+        ATOM    538  O   ASP A   1      -8.015   7.431  -5.518  1.00 95.46           O
+        ATOM    539  CG  ASP A   1      -9.818   4.542  -2.418  1.00 95.46           C
+        ATOM    540  OD1 ASP A   1     -10.899   4.073  -1.981  1.00 95.46           O
+        ATOM    541  OD2 ASP A   1      -8.738   3.930  -2.377  1.00 95.46           O
+        """)
+    r = only(only(only(read(io, PDBFormat))))
+    χs2 = chiangles(r)
+    @test χs1[1] ≈ χs2[1]
+    @test χs1[2] ≈ χs2[2] rtol=0.05  # the bonds are not exactly symmetric
 
     # Test ContactMap
     cas = collectatoms(struc_1AKE, calphaselector)[1:10]


### PR DESCRIPTION
This computes the standard `chi` angles for standard residues. The table was taken from http://www.mlb.co.jp/linux/science/garlic/doc/commands/dihedrals.html

~~This is best reviewed excluding whitespace differences, as the documentation has a lot of trailing whitespace and my editor is configured to delete it upon file saving. If this is undesirable, I can back this part of the change out.~~ I decided to back it out, as most is trailing whitespace in docs for the column-based (and thus whitespace-sensitive) PDB file.