### PR TITLE
Add error hint for extension packages

### DIFF
--- a/src/BioStructures.jl
+++ b/src/BioStructures.jl
@@ -27,6 +27,16 @@ include("mmcif.jl")
 include("download.jl")
 include("spatial.jl")
 
+function __init__()
+    Base.Experimental.register_error_hint(MethodError) do io, exc, _, _
+        if exc.f ∈ (rundssp, rundssp!, runstride, runstride!)
+            if isempty(methods(exc.f))
+                printstyled(io, "\nYou may need `using DSSP_jll` or `using STRIDE_jll` to load the appropriate methods."; color=:yellow)
+            end
+        end
+    end
+end
+
 @compile_workload begin
     let
         mktemp() do path, io


### PR DESCRIPTION
This provides a hint to the user about how to fix MethodErrors.

Before:
![image](https://github.com/user-attachments/assets/76da919b-c2b4-442e-aaef-30654c9f1a89)

After:
![image](https://github.com/user-attachments/assets/0da3d84f-7466-40e5-9fd0-d702edb24e30)
