### PR TITLE
Fix DomainError and silent 0.0 in bondangle/dihedralangle on degenerate geometry

### DIFF
--- a/src/spatial.jl
+++ b/src/spatial.jl
@@ -319,7 +319,8 @@ function bondangle(at_a::AbstractAtom,
 end
 
 function bondangle(vec_a::AbstractVector{<:Real}, vec_b::AbstractVector{<:Real})
-    return acos(dot(vec_a, vec_b) / (norm(vec_a) * norm(vec_b)))
+    # clamp guards against floating-point drift just outside [-1, 1] on near-parallel vectors
+    return acos(clamp(dot(vec_a, vec_b) / (norm(vec_a) * norm(vec_b)), -1, 1))
 end
 
 """
@@ -345,9 +346,13 @@ end
 function dihedralangle(vec_a::AbstractVector{<:Real},
                     vec_b::AbstractVector{<:Real},
                     vec_c::AbstractVector{<:Real})
-    return atan(
-        norm(vec_b) * dot(vec_a, cross(vec_b, vec_c)),
-        dot(cross(vec_a, vec_b), cross(vec_b, vec_c)))
+    cross_bc = cross(vec_b, vec_c)
+    y = norm(vec_b) * dot(vec_a, cross_bc)
+    x = dot(cross(vec_a, vec_b), cross_bc)
+    ang = atan(y, x)
+    # atan(0, 0) is 0, but here both terms vanish only for degenerate (collinear or
+    # coincident) input, where the dihedral is undefined
+    return iszero(x) && iszero(y) ? oftype(ang, NaN) : ang
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3271,6 +3271,24 @@ end
     vec_c = [1.0, -1.0, 1.0]
     @test isapprox(dihedralangle(vec_a, vec_b, vec_c), -0.785398, atol=1e-5)
 
+    # Near-linear angle where rounding pushes the acos argument past -1; must not throw
+    at_a = Atom(100, "CA", ' ', [0.5, 0.5, 0.5], 1.0, 10.0, " C", "  ", res)
+    at_b = Atom(100, "CA", ' ', [0.0, 0.0, 0.0], 1.0, 10.0, " C", "  ", res)
+    at_c = Atom(100, "CA", ' ', [-0.5, -0.5, -0.5], 1.0, 10.0, " C", "  ", res)
+    @test isapprox(bondangle(at_a, at_b, at_c), π)
+    @test isapprox(bondangle([0.5, 0.5, 0.5], [-0.5, -0.5, -0.5]), π)
+
+    # Degenerate dihedrals return NaN rather than a misleading 0.0
+    at_a = Atom(100, "CA", ' ', [0.0, 0.0, 0.0], 1.0, 10.0, " C", "  ", res)
+    at_b = Atom(100, "CA", ' ', [1.0, 0.0, 0.0], 1.0, 10.0, " C", "  ", res)
+    at_c = Atom(100, "CA", ' ', [2.0, 0.0, 0.0], 1.0, 10.0, " C", "  ", res)
+    at_d = Atom(100, "CA", ' ', [3.0, 0.0, 0.0], 1.0, 10.0, " C", "  ", res)
+    @test isnan(dihedralangle(at_a, at_b, at_c, at_d))
+    @test isnan(dihedralangle([1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]))
+    # Coincident pair (at_b == at_c) leaves the central vector zero
+    at_c = Atom(100, "CA", ' ', [1.0, 0.0, 0.0], 1.0, 10.0, " C", "  ", res)
+    @test isnan(dihedralangle(at_a, at_b, at_c, at_d))
+
     @test isapprox(omegaangle(struc_1AKE['A'][20], struc_1AKE['A'][19]), -3.09191, atol=1e-5)
     @test isapprox(phiangle(struc_1AKE['A'][7], struc_1AKE['A'][6]), 2.85115, atol=1e-5)
     @test isapprox(psiangle(struc_1AKE['A'][8], struc_1AKE['A'][9]), 2.83827, atol=1e-5)


### PR DESCRIPTION
Two small correctness fixes in the vector-form methods of `src/spatial.jl`.

1. `bondangle` can throw `DomainError` on legal geometry.

It computes `acos(dot / (norm * norm))` with no clamp. For near-parallel or
near-antiparallel bonds, floating point rounding can push the ratio just outside
`[-1, 1]` (for example `-1.0000000000000002`), and `acos` then throws. This is a
defensive fix: clamp the argument to `[-1, 1]` before `acos`. A genuinely coincident
atom still gives `0/0 = NaN`, which is left as the correct undefined result.

2. `dihedralangle` returns `0.0` for degenerate input.

For four collinear points, or a coincident pair, both `atan` arguments vanish and
`atan(0, 0)` is `0.0`. That is a valid looking value for an undefined angle, and it
flows into `phiangles`/`psiangles`/`omegaangles`/`chiangles`. The fix returns `NaN`
when both arguments are zero, matching the convention those same functions already
use for undefined angles. A genuine planar dihedral (0 or pi) is unaffected, since
only the degenerate case has both arguments zero. Caching `cross(vec_b, vec_c)`,
previously computed twice, keeps non-degenerate results identical and drops one
allocation.

Tests were added to the existing Spatial testset: a near-linear triple no longer
throws and returns approximately pi, and collinear and coincident-pair dihedrals
return NaN. Each assertion was confirmed to fail on the current code and pass after
the fix. The full test suite stays green, and a quick benchmark shows bondangle
unchanged and dihedralangle slightly faster with two fewer allocations.

Happy to add a NEWS.md entry if you would like one.
